### PR TITLE
Add import-garmin job: Garmin heart-rate (workouts) + sleep → DuckDB/PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ The repository uses a modular `polar` package organized by functionality:
 
 See [QUICKSTART.md](docs/QUICKSTART.md) for detailed usage instructions.
 
+## Import Jobs
+
+Containerized batch importers live under `jobs/`:
+
+- **`jobs/import/`** — Polar AccessLink workflow (download TCX → CSV → DuckDB/PostgreSQL → Azure).
+- **`jobs/import-garmin/`** — Garmin per-workout heart rate (with `workoutId` + GPS)
+  and sleep data into DuckDB/PostgreSQL, sourced from the GarminDB SQLite databases.
+  Selectable backend via `DATABASE_TYPE`; see [jobs/import-garmin/README.md](jobs/import-garmin/README.md).
+
 ## Devcontainer
 
 This repo includes a devcontainer setup for the Polar and Garmin Python/notebook workflows. VS Code auto-detects `.devcontainer/devcontainer.json`. It uses the Microsoft Python 3.14 Bookworm image and manages Python dependencies with `uv`.

--- a/docs/reports/2026-06-08_garmin_import_download_run.md
+++ b/docs/reports/2026-06-08_garmin_import_download_run.md
@@ -1,0 +1,183 @@
+# Garmin Import Job — Live Download Run Report (Run #2)
+
+**Date:** 2026-06-08
+**Run type:** Live download enabled (`GARMIN_DOWNLOAD=true`, `GARMIN_DOWNLOAD_LATEST=false` → download **all**)
+**Result:** ✅ **Success — all Garmin data downloaded from Garmin Connect and imported into the DuckDB tables.**
+**Evidence log:** `jobs/import-garmin/local_data/import-garmin_download_run_2026-06-08T15-24-08.log`
+**Companion run #1 (transform-only):** `docs/reports/2026-06-08_garmin_import_job.md`
+
+---
+
+## 1. Objective
+
+Run the import job with the **live download** enabled, to pull all data from
+Garmin Connect and import it into the DuckDB tables. Capture logs to a separate
+file, inspect them, fix any issues found, and iterate until the download + import
+succeeds. Success criterion: successful download of all Garmin data and import
+into the DuckDB tables, with table counts reported.
+
+---
+
+## 2. Outcome — DuckDB table counts
+
+The job ran in Docker and **exited 0**. Fresh data was downloaded from Garmin
+Connect (293 activities + sleep) and imported:
+
+| Table | Row count |
+|-------|-----------|
+| `garmin_workout_metadata` | **293** |
+| `garmin_timeseries` | **112 983** |
+| `garmin_sleep` | **205** |
+
+Compared with the transform-only run #1 (which used 3-month-old data), the live
+download brought the dataset up to date:
+
+| Table | Run #1 (stale) | Run #2 (live download) |
+|-------|---------------:|-----------------------:|
+| `garmin_workout_metadata` | 193 | **293** |
+| `garmin_timeseries` | 80 295 | **112 983** |
+| `garmin_sleep` | 135 | **205** |
+
+---
+
+## 3. Token
+
+The previously-stored garth token was expired (refresh token expired 2026-04-14),
+so it was renewed via the host helper script `./scripts/renew_garmin_token.sh` (Garmin
+login + MFA). The renewed token's refresh validity runs to **2026-07-08**. The job
+copies/refreshes this token from the mounted `~/.GarminDb/garth_session` on every
+run.
+
+---
+
+## 4. Issues found while iterating (and fixed)
+
+Reaching a successful run surfaced several real problems, all fixed:
+
+1. **Silent download failure (exit-code blindness).** `garmindb_cli` prints
+   `Failed to login!` but still **exits 0** on auth failure, so the job originally
+   reported success and silently transformed stale data. Fixed in
+   `garmin_etl/download.py` with a **preflight token-expiry check** plus **CLI
+   output capture + failure-marker scanning**.
+2. **No abort on required-download failure.** Added `GARMIN_DOWNLOAD_REQUIRED`
+   (default true): a failed required download now **aborts (exit 1)** instead of
+   importing stale data.
+3. **Wrong garmindb version / token format.** Pinned **`garmindb==3.7.0`** (garth
+   single-file `garth_session`, matching the token format); 3.8.x switched to an
+   incompatible token store. Bumped `requires-python>=3.10`; enabled the
+   `download` extra in the `Dockerfile`.
+4. **Stale cached token won over the fresh one.** The container reused a stale
+   `local_data/.GarminDb/garth_session` copied by an earlier run (persisted on the
+   mounted volume) instead of the freshly renewed host token, so it kept reporting
+   the *old* expiry. Fixed `_ensure_session_token()` to treat the host token
+   (`~/.GarminDb/garth_session`) as the source of truth and **refresh the
+   config-dir copy from it on every run**.
+5. **Sleep download scanned years of empty days.** With the default
+   `GARMIN_START_DATE=01/01/2020`, GarminDB downloaded sleep day-by-day for ~2350
+   days (~45 min), most predating the device. Set `GARMIN_START_DATE=10/01/2025`
+   (just before the account's first data) so all real data is captured quickly.
+6. **Empty placeholder sleep rows.** GarminDB seeds empty `sleep` rows
+   (`total_sleep=0`, null timestamps) for days with no recorded sleep. The
+   transform's filter kept them (0 is not null), inflating the count to 342. Fixed
+   `build_sleep()` to keep a row only when it has real sleep duration (`> 0`) or a
+   sleep-start timestamp → **205 genuine sleep nights**.
+
+---
+
+## 5. Docker run (evidence)
+
+```bash
+cd jobs/import-garmin
+./scripts/renew_garmin_token.sh                                 # one-time: renew the token
+docker compose build                                    # image includes garmindb 3.7.0
+docker compose up --no-build --abort-on-container-exit
+```
+
+Full log: `jobs/import-garmin/local_data/import-garmin_download_run_2026-06-08T15-24-08.log`.
+Key excerpt:
+
+```
+Step 2: Downloading latest data from Garmin (GarminDB CLI)...
+  Refreshed garth_session from /root/.GarminDb/garth_session
+  Running: .../garmindb_cli.py -f /app/local_data/.GarminDb --all --download --import
+  ___Downloading All Data___
+  Getting activities: '/app/local_data/garmin_sqlite/FitFiles/Activities' (1000) ...
+  Downloading all sleep data from: 2025-10-01 [250]
+  ✅ GarminDB download + import complete
+Step 3: Transforming GarminDB SQLite data...
+  Transformed: 293 workouts (289 with GPS), 112983 records, 205 sleep nights
+Step 4: Loading into DUCKDB...
+  ✅ DuckDB workouts: upserted 293 (table total 293); timeseries rows 112983 (table total 112983)
+  ✅ DuckDB sleep: upserted 205 (table total 205)
+✅ GARMIN IMPORT JOB COMPLETE
+garmin-import-job exited with code 0
+JOB_EXIT_CODE=0
+```
+
+(The full log also contains the per-activity download and per-day sleep download
+progress bars.)
+
+---
+
+## 6. DuckDB verification
+
+All queries run against `jobs/import-garmin/local_data/garmin.duckdb` (7.6 MB).
+
+| Check | Result |
+|-------|--------|
+| Tables present | `garmin_workout_metadata`, `garmin_timeseries`, `garmin_sleep` |
+| `workoutId` total / distinct / null / valid-format | 293 / 293 / 0 / 293 |
+| GPS coverage (`gps_source`) | `first_record` 289, `none` 4 |
+| Timeseries `workoutId` nulls / orphans | 0 / 0 |
+| Sleep rows with real sleep (`total_sleep_s > 0`) | 205 / 205 |
+| Sleep distinct days | 205 |
+| Workout date range (`start_time`) | 2025-11-09 → **2026-06-08 11:56** |
+| Sleep date range (`day`) | 2025-11-09 → 2026-06-07 |
+| HR (timeseries) min / mean / max / nulls | 0 / 134 / 195 / 113 |
+
+Sample (latest 3 workouts):
+
+```
+        workoutId   activity_id   sport          start_time  distance  calories  avg_hr      lat      lon
+08-06-2026_115609   23172952391   generic 2026-06-08 11:56:09   0.21093        89     119  36.6504  -4.7775
+08-06-2026_105613   23172523660   generic 2026-06-08 10:56:13   0.23098       187     163  36.6679  -4.7417
+27-05-2026_114558   23029407739   generic 2026-05-27 11:45:58   0.22968        82     109  36.6680  -4.7421
+```
+
+Sample (latest 3 sleep nights):
+
+```
+       day          sleep_start            sleep_end  total_sleep_s  score  qualifier
+2026-06-07  2026-06-06 21:54:57  2026-06-07 04:47:20          22643     56       POOR
+2026-06-06  2026-06-05 21:06:34  2026-06-06 05:20:57          28703     92  EXCELLENT
+2026-06-05  2026-06-04 21:27:28  2026-06-05 05:22:28          27960     92  EXCELLENT
+```
+
+Data reaches **today (2026-06-08)** — confirming the live download pulled fresh
+data. `workoutId` is unique and correctly formatted, every per-second HR row links
+to a workout, and only genuine sleep nights are retained.
+
+---
+
+## 7. Configuration used
+
+| Setting | Value |
+|---------|-------|
+| `DATABASE_TYPE` | `duckdb` |
+| `GARMIN_DOWNLOAD` | `true` |
+| `GARMIN_DOWNLOAD_LATEST` | `false` (download all) |
+| `GARMIN_DOWNLOAD_REQUIRED` | `true` |
+| `GARMIN_START_DATE` | `10/01/2025` |
+| garmindb | `3.7.0` (download extra) |
+
+Enabled GarminDB stats: **activities + sleep** (matching what the job imports).
+
+---
+
+## 8. Status
+
+✅ **Success criteria met.** The job authenticated with the renewed token,
+downloaded all Garmin data (293 activities + sleep) from Garmin Connect, imported
+it through the GarminDB SQLite layer, transformed it, and upserted into the DuckDB
+tables — **293 workouts (289 with GPS), 112 983 per-second HR/GPS rows, 205 sleep
+nights** — with the container exiting 0 and all integrity checks passing.

--- a/docs/reports/2026-06-08_garmin_import_job.md
+++ b/docs/reports/2026-06-08_garmin_import_job.md
@@ -1,0 +1,345 @@
+# Garmin Import Job — Full Work Report
+
+**Date:** 2026-06-08
+**Status:** ✅ Complete — Docker job runs successfully; DuckDB and PostgreSQL both verified
+**Job location:** `jobs/import-garmin/`
+**Evidence log:** `jobs/import-garmin/local_data/import-garmin_run_2026-06-08T13-13-51.log`
+**Output database:** `jobs/import-garmin/local_data/garmin.duckdb` (5.5 MB)
+
+---
+
+## 1. Objective
+
+Create a new containerized import job (`jobs/import-garmin/`) that imports **Garmin
+per-workout heart rate** and **sleep** data into both **DuckDB** and **PostgreSQL**,
+selectable via a `.env` switch, mirroring the existing Polar job at `jobs/import/`.
+
+Requirements:
+1. Understand the GarminDB notebooks (`garmin/GarminDB-notebooks/`, upstream
+   [tcgoetz/GarminDB](https://github.com/tcgoetz/GarminDB)) and how to get all
+   Garmin data.
+2. New import job `import-garmin` runnable under Docker locally.
+3. Import **heart rate** + **sleep** into DuckDB and PostgreSQL, with **two data
+   layers** per DB type and a `.env` switch. For heart rate: generate a `workoutId`
+   like the Polar database and link it as a key via a metadata table; add **GPS
+   coordinates** to the heart-rate metadata (first GPS coordinate when multiple).
+4. Store data under `import-garmin/local_data` (file-system mount).
+5. Provide an MD-style notebook to query the DuckDB Garmin tables, under the job
+   folder, **excluded from the Dockerfile**.
+6. Success = the job runs in local Docker and imports all Garmin workouts + sleep
+   into DuckDB.
+
+---
+
+## 2. How Garmin data is obtained (investigation)
+
+- **GarminDB** (clone in `garmin/GarminDB-notebooks/`) is a tool that downloads
+  Garmin Connect data via its CLI `garmindb_cli.py --all --download --import
+  --analyze [--latest]` and stores it in **SQLite** databases.
+- Data was **already downloaded** on this machine into `data/sqlite/DBs/`:
+  - `garmin_activities.db` → `activities` (per-workout metadata: `start_time`,
+    `sport`, `start_lat/long`, `avg_hr`, `calories`, …) and `activity_records`
+    (per-second `timestamp`, `hr`, `position_lat`, `position_long`, `speed`, …).
+  - `garmin.db` → `sleep` (daily: `day`, `start`, `end`, `total_sleep`,
+    `deep_sleep`, `light_sleep`, `rem_sleep`, `awake`, `score`, `qualifier`).
+- **Authentication** uses the `garth` library with a session token at
+  `~/.GarminDb/garth_session` (base64 OAuth1+OAuth2). GarminDB resumes it via
+  `garth.loads()` and auto-refreshes while the ~1-year refresh token is valid; the
+  username/password in `GarminConnectConfig.json` are empty (token-based).
+
+**Data sourcing decision (confirmed with user):** Support both. The default local
+Docker test is **transform-only** (reads the already-downloaded SQLite DBs seeded
+into `local_data`), with an **optional live download** phase via
+`GARMIN_DOWNLOAD=true` using the garth session. This guarantees a reliable,
+network-independent local Docker run while still supporting fresh downloads.
+
+---
+
+## 3. Architecture & data model
+
+```
+jobs/import-garmin/
+  main.py                 # orchestrator: (opt) download → transform → load → summary
+  garmin_etl/
+    config.py             # env-based config; DATABASE_TYPE + GARMIN_DOWNLOAD switches
+    transform.py          # GarminDB SQLite → clean DataFrames (workoutId + first GPS)
+    download.py           # optional GarminDB CLI download phase (garth session)
+    storage/
+      duckdb.py           # DuckDB data layer (explicit DDL, idempotent upsert)
+      postgres.py         # PostgreSQL data layer (mirror of duckdb.py)
+  notebooks/query_garmin_duckdb.md  # MyST query notebook (EXCLUDED from image)
+  Dockerfile, docker-compose.yml, pyproject.toml, .env(.example), README.md
+  local_data/             # mount: garmin_sqlite/DBs (input) + garmin.duckdb (output) + logs
+```
+
+**Two data layers, one switch:** `garmin_etl/storage/duckdb.py` and
+`garmin_etl/storage/postgres.py` expose the same surface (`import_workouts`,
+`import_sleep`, query helpers, `delete_workout_by_id`). `main.py` selects the
+backend at runtime from `DATABASE_TYPE` (`duckdb` | `postgres`) read from `.env`.
+
+**Tables (all `garmin_`-prefixed; dedicated `garmin.duckdb`, not Polar's DB):**
+
+| Table | Grain | Key | Notes |
+|-------|-------|-----|-------|
+| `garmin_workout_metadata` | 1 row / workout | PK `activity_id` | Carries `workoutId` (`DD-MM-YYYY_HHMMSS` from `start_time`) + `gps_lat`/`gps_long`/`gps_source`. |
+| `garmin_timeseries` | per-second | PK `(activity_id, record)` | Per-second `hr`, `position_lat/long`, `speed`, …; linked by `activity_id` + `workoutId`. |
+| `garmin_sleep` | daily | PK `day` | Durations as integer seconds; reserved `end` renamed to `sleep_end`. |
+
+**`workoutId`**: built as `DD-MM-YYYY_HHMMSS` from the activity `start_time`
+(matching the Polar convention). It is used as a join key, so same-second
+collisions are auto-disambiguated with a numeric suffix (`-2`, `-3`, …);
+`activity_id` remains the durable primary key.
+
+**First GPS coordinate**: the first `activity_records` row (ordered by `record`,
+`timestamp`) where both `position_lat` and `position_long` are present and in
+valid range; falls back to `activities.start_lat/long`. `gps_source` records the
+origin (`first_record` | `activity_start` | `none`).
+
+**Data integrity choices:** explicit DDL (no pandas type inference), durations
+converted to integer seconds, timestamps stored as local-naive wall-clock,
+nullable integers bound as `NULL` (never `NaN`), idempotent delete-by-id upserts.
+
+---
+
+## 4. File inventory
+
+| File | LOC | Purpose |
+|------|-----|---------|
+| `main.py` | 105 | Orchestrator + summary |
+| `garmin_etl/config.py` | 160 | Env config + switches |
+| `garmin_etl/transform.py` | 381 | SQLite → DataFrames, workoutId, first GPS, preflight |
+| `garmin_etl/download.py` | 154 | Optional GarminDB CLI download phase |
+| `garmin_etl/storage/duckdb.py` | 265 | DuckDB data layer |
+| `garmin_etl/storage/postgres.py` | 354 | PostgreSQL data layer |
+| `garmin_etl/__init__.py`, `storage/__init__.py` | 14 | Package docstrings |
+
+Plus: `Dockerfile`, `docker-compose.yml`, `pyproject.toml`, `.env` / `.env.example`,
+`.gitignore`, `.dockerignore`, `README.md`, `notebooks/query_garmin_duckdb.md`, `scripts/renew_garmin_token.*`.
+
+Documentation: top-level `README.md` updated with an **Import Jobs** section.
+
+---
+
+## 5. Docker run (evidence)
+
+Command:
+
+```bash
+cd jobs/import-garmin
+docker compose up --build --abort-on-container-exit
+```
+
+**Result: container exited with code 0.** Full log captured at
+`jobs/import-garmin/local_data/import-garmin_run_2026-06-08T13-13-51.log`.
+Key excerpt:
+
+```
+Step 3: Transforming GarminDB SQLite data...
+  Reading activities from /app/local_data/garmin_sqlite/DBs/garmin_activities.db
+  Reading activity_records from /app/local_data/garmin_sqlite/DBs/garmin_activities.db
+  Reading sleep from /app/local_data/garmin_sqlite/DBs/garmin.db
+  Transformed: 193 workouts (189 with GPS), 80295 records, 135 sleep nights
+
+Step 4: Loading into DUCKDB...
+  ✅ DuckDB workouts: upserted 193 (table total 193); timeseries rows 80295 (table total 80295)
+  ✅ DuckDB sleep: upserted 135 (table total 135)
+
+✅ GARMIN IMPORT JOB COMPLETE
+  - Database type:        DUCKDB
+  - Workouts imported:    193 (table total 193)
+  - Timeseries rows:      80295 (table total 80295)
+  - Sleep nights:         135 (table total 135)
+  - DuckDB file:          /app/local_data/garmin.duckdb
+garmin-import-job exited with code 0
+```
+
+---
+
+## 6. DuckDB verification
+
+All queries run against `jobs/import-garmin/local_data/garmin.duckdb` (read-only).
+
+### 6.1 Tables present
+```
+garmin_sleep
+garmin_timeseries
+garmin_workout_metadata
+```
+
+### 6.2 Row counts
+| table | rows |
+|-------|------|
+| garmin_workout_metadata | 193 |
+| garmin_timeseries | 80295 |
+| garmin_sleep | 135 |
+
+### 6.3 `workoutId` integrity
+| total | distinct_wid | null_wid | valid_format (`DD-MM-YYYY_HHMMSS[-n]`) |
+|-------|--------------|----------|----------------------------------------|
+| 193 | 193 | 0 | 193 |
+
+→ Every workout has a unique, correctly-formatted, non-null `workoutId`.
+
+### 6.4 GPS coverage (`gps_source`)
+| gps_source | workouts |
+|------------|----------|
+| first_record | 189 |
+| none | 4 |
+
+→ 189/193 workouts carry a GPS fix (the 4 without are indoor activities with no
+GPS records in the source), satisfying "add GPS coordinates; use the first when
+multiple".
+
+### 6.5 Timeseries linkage
+- `workoutId` NULLs in `garmin_timeseries`: **0** of 80,295.
+- Orphan timeseries rows (workoutId not present in metadata): **0**.
+
+→ Every per-second HR row is correctly linked to a workout via `workoutId`.
+
+### 6.6 Date ranges
+| dataset | min | max |
+|---------|-----|-----|
+| workouts (`start_time`) | 2025-11-09 14:04:31 | 2026-03-16 18:59:52 |
+| timeseries (`timestamp`) | 2025-11-09 14:04:31 | 2026-03-16 19:10:00 |
+| sleep (`day`) | 2025-11-01 | 2026-03-15 |
+
+### 6.7 HR sanity (timeseries)
+| min_hr | max_hr | mean_hr | null_hr |
+|--------|--------|---------|---------|
+| 0 | 195 | 133 | 69 |
+
+→ HR values are within a plausible range; only 69 of 80,295 rows have a null HR
+(sensor gaps), preserved as `NULL`.
+
+### 6.8 Sample workouts (latest 5)
+```
+        workoutId activity_id   sport          start_time  distance  calories  avg_hr  max_hr  gps_lat   gps_long   gps_source
+16-03-2026_185952 22198283333 generic 2026-03-16 18:59:52   0.13793       127     155     178 47.75628 -122.24000 first_record
+16-03-2026_184554 22198212882 generic 2026-03-16 18:45:54   0.10683        36     100     132 47.75629 -122.23993 first_record
+15-03-2026_113550 22186157118 generic 2026-03-15 11:35:50  26.15854       426      96     132 47.75627 -122.23993 first_record
+14-03-2026_123907 22174408697 generic 2026-03-14 12:39:07   1.55884       131     139     195 47.72793 -122.24486 first_record
+14-03-2026_114402 22174227380 generic 2026-03-14 11:44:02   1.46376       179      86     143 47.75617 -122.23991 first_record
+```
+
+### 6.9 Sample sleep (latest 5)
+```
+       day         sleep_start           sleep_end  total_sleep_s  deep_sleep_s  light_sleep_s  rem_sleep_s  score qualifier
+2026-03-15 2026-03-15 00:42:37 2026-03-15 08:28:37          27660          3780          19200         4680     77      FAIR
+2026-03-14 2026-03-14 01:02:13 2026-03-14 08:45:53          27100          3780          18480         4860     70      FAIR
+2026-03-13 2026-03-13 00:14:32 2026-03-13 06:10:32          20280          3540          14580         2160     66      FAIR
+2026-03-12 2026-03-11 23:35:31 2026-03-12 06:10:31          23640          4680          15480         3480     78      FAIR
+2026-03-11 2026-03-10 23:27:07 2026-03-11 06:10:07          23700          3000          17160         3540     64      FAIR
+```
+
+### 6.10 Column schema (explicit DDL verified)
+- `garmin_workout_metadata` (23 cols): `activity_id VARCHAR`, `workoutId VARCHAR`,
+  `name`, `sport`, `sub_sport`, `start_time TIMESTAMP`, `stop_time TIMESTAMP`,
+  `elapsed_time_s INTEGER`, `moving_time_s INTEGER`, `distance DOUBLE`,
+  `calories INTEGER`, `avg_hr INTEGER`, `max_hr INTEGER`, `avg_speed DOUBLE`,
+  `max_speed DOUBLE`, `avg_cadence INTEGER`, `ascent DOUBLE`, `descent DOUBLE`,
+  `training_load DOUBLE`, `training_effect DOUBLE`, `gps_lat DOUBLE`,
+  `gps_long DOUBLE`, `gps_source VARCHAR`.
+- `garmin_timeseries` (13 cols): `activity_id VARCHAR`, `workoutId VARCHAR`,
+  `record INTEGER`, `timestamp TIMESTAMP`, `hr INTEGER`, `position_lat DOUBLE`,
+  `position_long DOUBLE`, `speed DOUBLE`, `distance DOUBLE`, `cadence INTEGER`,
+  `altitude DOUBLE`, `temperature DOUBLE`, `rr DOUBLE`.
+- `garmin_sleep` (13 cols): `day DATE`, `sleep_start TIMESTAMP`,
+  `sleep_end TIMESTAMP`, `total_sleep_s INTEGER`, `deep_sleep_s INTEGER`,
+  `light_sleep_s INTEGER`, `rem_sleep_s INTEGER`, `awake_s INTEGER`,
+  `avg_spo2 DOUBLE`, `avg_rr DOUBLE`, `avg_stress DOUBLE`, `score INTEGER`,
+  `qualifier VARCHAR`.
+
+---
+
+## 7. Completeness vs. source (no data loss)
+
+| Metric | Source (GarminDB SQLite) | DuckDB output | Match |
+|--------|--------------------------|---------------|-------|
+| Activities / workouts | 193 | 193 | ✅ |
+| Activity records / timeseries | 80,295 | 80,295 | ✅ |
+| Sleep nights | 135 | 135 | ✅ |
+| Activities with GPS | 189 | 189 (`first_record`) | ✅ |
+
+→ 100% of source rows imported; no rows dropped or duplicated.
+
+---
+
+## 8. Idempotency & PostgreSQL (earlier verification)
+
+- **Idempotency (DuckDB):** Re-running the job leaves counts unchanged
+  (193 / 80,295 / 135) — delete-by-id upsert is idempotent.
+- **PostgreSQL layer:** Verified against a local Postgres 16 container with
+  `DATABASE_TYPE=postgres`: imported the same 193 / 80,295 / 135 rows, correct
+  column types (`text`, `timestamp without time zone`, `integer`,
+  `double precision`), valid `workoutId` + GPS, and idempotent on re-run.
+- **Disambiguation unit test:** Synthetic same-second collisions produce unique
+  `workoutId`s (`…185952`, `…185952-2`, `…185952-3`) — verified.
+
+---
+
+## 9. Code-review fixes applied
+
+A code review of the new job led to these hardening changes (all re-verified):
+
+1. **Rollback no longer masks the original error** — `ROLLBACK` / `conn.rollback()`
+   wrapped in `try/except pass` in both storage layers so the root-cause exception
+   is preserved.
+2. **Same-second `workoutId` collisions** are auto-disambiguated with a numeric
+   suffix instead of aborting the whole batch — keeps `workoutId` unique for joins
+   while remaining resilient for unattended runs.
+3. Removed dead helper code; explicit per-backend row conversion retained.
+
+---
+
+## 10. How to run
+
+```bash
+cd jobs/import-garmin
+cp .env.example .env                 # defaults: DATABASE_TYPE=duckdb, GARMIN_DOWNLOAD=false
+
+# Seed the already-downloaded GarminDB SQLite DBs (input):
+mkdir -p local_data/garmin_sqlite/DBs
+cp ../../data/sqlite/DBs/garmin_activities.db local_data/garmin_sqlite/DBs/
+cp ../../data/sqlite/DBs/garmin.db            local_data/garmin_sqlite/DBs/
+
+docker compose up --build            # → writes local_data/garmin.duckdb
+
+# PostgreSQL: set DATABASE_TYPE=postgres + POSTGRES_* in .env
+```
+
+Query the result with `notebooks/query_garmin_duckdb.md` (excluded from the image).
+
+### Optional live download from Garmin
+Set `GARMIN_DOWNLOAD=true`, build with the `download` extra (uncomment the
+`--extra download` line in the `Dockerfile`), and mount `~/.GarminDb` (done by
+`docker-compose.yml`). If the garth token is expired, regenerate once on the host:
+
+```bash
+pip install garmindb
+garmindb_cli.py --download --latest   # prompts Garmin login + MFA; rewrites ~/.GarminDb/garth_session
+```
+
+The default transform-only path requires **no token** — which is why the verified
+Docker run above succeeded without any credential input.
+
+---
+
+## 11. Notes & limitations
+
+- The already-downloaded source data ends **2026-03-16**; enable the download
+  phase to refresh to the present.
+- "Heart rate" = per-workout/activity HR (with `workoutId` + GPS), per the
+  confirmed scope. All-day monitoring HR is intentionally out of scope.
+- Timestamps are stored as local-naive wall clock; `GARMIN_LOCAL_TIMEZONE`
+  (default `UTC`) is reserved as future metadata for Polar↔Garmin correlation.
+- `garmin.duckdb`, the seeded SQLite DBs, the run log, `.venv`, and `.env` are all
+  git-ignored; only source/config files are tracked.
+
+---
+
+## 12. Status
+
+✅ **Success criteria met.** The `import-garmin` job runs successfully in local
+Docker (exit 0) and imports **all** Garmin workouts (193, with per-second HR and
+first-GPS) and **all** sleep nights (135) into DuckDB, with a verified PostgreSQL
+path and idempotent re-runs.

--- a/jobs/import-garmin/.dockerignore
+++ b/jobs/import-garmin/.dockerignore
@@ -1,0 +1,40 @@
+# Query notebook — explicitly excluded from the image (per requirement).
+notebooks/
+
+# Token-renewal helpers — host-only utilities, excluded from the image.
+scripts/
+
+# Runtime data + secrets (mounted/injected at runtime, never baked in).
+local_data/
+.env
+garth_session
+
+# Python caches / build artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+.uv/
+uv.lock
+
+# Notebook checkpoints
+.ipynb_checkpoints/
+
+# garmindb writes this log to the working directory at runtime
+garmindb.log
+
+# IDEs / OS
+.vscode/
+.idea/
+*.swp
+.DS_Store

--- a/jobs/import-garmin/.env.example
+++ b/jobs/import-garmin/.env.example
@@ -1,0 +1,59 @@
+# =============================================================================
+# Database backend switch
+# =============================================================================
+# Which data layer to load into: 'duckdb' (default) or 'postgres'.
+DATABASE_TYPE=duckdb
+
+# =============================================================================
+# Garmin source / download
+# =============================================================================
+# When false (default), the job transforms the already-downloaded GarminDB
+# SQLite databases. When true, it first runs the GarminDB CLI to refresh them
+# (requires the 'download' extra + a valid garth_session token).
+GARMIN_DOWNLOAD=false
+# When downloading, only fetch the latest data (incremental) vs. everything.
+GARMIN_DOWNLOAD_LATEST=true
+# When true (default), a download failure aborts the job instead of silently
+# falling back to existing (possibly stale) SQLite databases.
+GARMIN_DOWNLOAD_REQUIRED=true
+
+# Directory holding the GarminDB SQLite DBs (garmin_activities.db, garmin.db).
+# Relative paths resolve against the job directory.
+GARMIN_DB_DIR=local_data/garmin_sqlite/DBs
+# GarminDB base dir (download phase writes DBs into <base>/DBs).
+GARMIN_BASE_DIR=local_data/garmin_sqlite
+# Config dir for the download phase (holds GarminConnectConfig.json + garth_session).
+# Defaults to local_data/.GarminDb when unset.
+# GARMIN_CONFIG_DIR=local_data/.GarminDb
+
+# Dedicated DuckDB output file (kept separate from Polar's database_v2.duckdb).
+GARMIN_DUCKDB_PATH=local_data/garmin.duckdb
+
+# Timezone metadata only (timestamps are stored as local-naive wall clock).
+GARMIN_LOCAL_TIMEZONE=UTC
+
+# Optional download-phase tuning:
+# GARMIN_START_DATE=01/01/2020   # earliest date (MM/DD/YYYY) to pull sleep from
+# GARMIN_DOWNLOAD_ALL_ACTIVITIES=1000
+# GARMIN_DOWNLOAD_LATEST_ACTIVITIES=25
+# GARMIN_DOMAIN=garmin.com
+
+# =============================================================================
+# PostgreSQL (required when DATABASE_TYPE=postgres)
+# =============================================================================
+POSTGRES_HOST=your_postgres_host
+POSTGRES_PORT=5432
+POSTGRES_DATABASE=workoutdata
+POSTGRES_USER=your_username
+POSTGRES_PASSWORD=your_password
+# 'prefer' for local, 'require' for Azure PostgreSQL.
+POSTGRES_SSLMODE=prefer
+# Alternatively provide a full connection string:
+# POSTGRES_CONNECTION_STRING=postgresql://user:pass@host:5432/workoutdata
+
+# =============================================================================
+# Azure Storage (optional, reserved for future DuckDB upload)
+# =============================================================================
+AZURE_STORAGE_ENABLED=false
+AZURE_STORAGE_ACCOUNT_NAME=your_storage_account_name
+AZURE_STORAGE_CONTAINER_NAME=workout-data

--- a/jobs/import-garmin/.gitignore
+++ b/jobs/import-garmin/.gitignore
@@ -4,7 +4,6 @@ garth_session
 
 # Local data (DuckDB output, GarminDB SQLite input, generated config)
 local_data/*
-!local_data/.gitkeep
 
 # Python
 __pycache__/

--- a/jobs/import-garmin/.gitignore
+++ b/jobs/import-garmin/.gitignore
@@ -1,0 +1,40 @@
+# Environment and credentials
+.env
+garth_session
+
+# Local data (DuckDB output, GarminDB SQLite input, generated config)
+local_data/*
+!local_data/.gitkeep
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# UV
+.uv/
+uv.lock
+
+# Jupytext / notebook checkpoints
+.ipynb_checkpoints/
+
+# garmindb writes this log to the working directory at runtime
+garmindb.log
+
+# IDEs / OS
+.vscode/
+.idea/
+*.swp
+.DS_Store

--- a/jobs/import-garmin/Dockerfile
+++ b/jobs/import-garmin/Dockerfile
@@ -1,0 +1,30 @@
+# Dockerfile for the Garmin Import Job.
+# Transforms GarminDB SQLite data into DuckDB / PostgreSQL (garmin_ tables).
+# The optional live-download phase (GARMIN_DOWNLOAD=true) additionally needs the
+# 'download' extra (garmindb); enable it by switching the uv sync line below.
+
+FROM python:3.11-slim
+
+# Install uv (fast Python package manager).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -LsSf https://astral.sh/uv/install.sh | sh
+
+ENV PATH="/root/.local/bin:/root/.cargo/bin:${PATH}"
+
+WORKDIR /app
+
+# Copy the self-contained job (build context = this job directory).
+COPY . /app
+
+# Install dependencies. The 'download' extra (garmindb) is required for the live
+# download phase (GARMIN_DOWNLOAD=true). For transform-only, you may drop it:
+#   RUN uv sync --no-dev
+RUN uv sync --no-dev --extra download
+
+# Ensure logs stream straight to the container output.
+ENV PYTHONUNBUFFERED=1
+ENV IN_CONTAINER=true
+
+CMD ["uv", "run", "python", "/app/main.py"]

--- a/jobs/import-garmin/README.md
+++ b/jobs/import-garmin/README.md
@@ -1,0 +1,134 @@
+# Garmin Import Job
+
+Imports **Garmin per-workout heart rate** (with `workoutId` + GPS) and **sleep**
+data into **DuckDB** or **PostgreSQL**, selectable via `DATABASE_TYPE`. It mirrors
+the structure of the Polar job at `../import/`.
+
+Data originates from the [GarminDB](https://github.com/tcgoetz/GarminDB) SQLite
+databases. By default the job **transforms the already-downloaded** SQLite DBs;
+optionally it can **download fresh data** from Garmin first.
+
+## What gets imported
+
+| Table | Source | Description |
+|-------|--------|-------------|
+| `garmin_workout_metadata` | `garmin_activities.db` → `activities` | One row per activity. PK `activity_id`; carries `workoutId` (`DD-MM-YYYY_HHMMSS` from `start_time`) and `gps_lat`/`gps_long` (first valid GPS fix, `gps_source` records origin). |
+| `garmin_timeseries` | `garmin_activities.db` → `activity_records` | Per-second `hr`, `position_lat/long`, `speed`, `distance`, `cadence`, `altitude`. Linked by `activity_id` + `workoutId`. |
+| `garmin_sleep` | `garmin.db` → `sleep` | Daily sleep summary. Durations stored as integer seconds; `start`/`end` renamed to `sleep_start`/`sleep_end`. |
+
+Durations are converted to integer seconds; timestamps are stored as local-naive
+wall-clock values. Imports are **idempotent** (delete-by-id upsert).
+
+## Layout
+
+```
+jobs/import-garmin/
+  main.py                 # orchestrator: (opt) download → transform → load → summary
+  garmin_etl/
+    config.py             # env-based config + DATABASE_TYPE / GARMIN_DOWNLOAD switches
+    transform.py          # GarminDB SQLite → clean DataFrames (workoutId, first GPS)
+    download.py           # optional GarminDB CLI download phase
+    storage/duckdb.py     # DuckDB data layer
+    storage/postgres.py   # PostgreSQL data layer
+  notebooks/
+    query_garmin_duckdb.md  # query notebook (EXCLUDED from the Docker image)
+  scripts/
+    renew_garmin_token.sh   # host-only token renewal wrapper (EXCLUDED from image)
+    renew_garmin_token.py   # token renewal helper (EXCLUDED from image)
+  Dockerfile, docker-compose.yml, pyproject.toml, .env(.example)
+  local_data/             # mount: garmin_sqlite/DBs (input) + garmin.duckdb (output)
+```
+
+## Setup
+
+1. Copy and edit the environment file:
+   ```bash
+   cp .env.example .env
+   ```
+2. Provide the GarminDB SQLite databases under `local_data/garmin_sqlite/DBs/`:
+   ```bash
+   mkdir -p local_data/garmin_sqlite/DBs
+   cp ../../data/sqlite/DBs/garmin_activities.db local_data/garmin_sqlite/DBs/
+   cp ../../data/sqlite/DBs/garmin.db            local_data/garmin_sqlite/DBs/
+   ```
+
+## Usage
+
+```bash
+cd jobs/import-garmin
+
+# DuckDB (default)
+docker compose build
+docker compose up
+
+# PostgreSQL: set DATABASE_TYPE=postgres + POSTGRES_* in .env
+```
+
+Output (DuckDB) lands at `local_data/garmin.duckdb`.
+
+### Run without Docker
+
+```bash
+uv run python main.py          # or: pip install -e . && python main.py
+```
+
+## Optional: live download from Garmin
+
+Set `GARMIN_DOWNLOAD=true` in `.env`. This runs the GarminDB CLI
+(`garmindb_cli.py --all --download --import [--latest]`) before transforming, using
+a job-generated `GarminConnectConfig.json` (pinned to `local_data/garmin_sqlite`,
+`metric=true`, activities + sleep enabled). Requirements:
+
+- Install the download extra: build with `uv sync --no-dev --extra download` (the
+  `Dockerfile` already does this), or `pip install 'garmindb==3.7.0'` locally.
+  The job pins **`garmindb==3.7.0`** (garth-based, single-file `garth_session`) to
+  match the token format already in use; newer 3.8.x uses a different token store.
+- A valid **garth session token**. The job reuses `~/.GarminDb/garth_session`
+  (mounted into the container by `docker-compose.yml`). It performs a preflight
+  check and **aborts with a clear message if the token is expired** rather than
+  silently importing stale data.
+
+### Regenerating the garth token
+
+garth refresh tokens expire (~1 year). If expired, run the helper script (it
+prompts for email, password, and MFA, then writes the exact single-file format
+this job expects to `~/.GarminDb/garth_session`):
+
+```bash
+cd jobs/import-garmin
+./scripts/renew_garmin_token.sh
+```
+
+The `scripts/renew_garmin_token.sh` wrapper ensures `garth` is installed and then
+runs `scripts/renew_garmin_token.py` (which performs the OAuth/MFA login — that
+part needs the `garth` Python library and can't be pure shell). Both files are
+host-only and excluded from the Docker image. Equivalent one-liner:
+
+```bash
+uv run python -c "import garth, getpass, os; \
+garth.login(input('Garmin email: '), getpass.getpass('Garmin password: ')); \
+open(os.path.expanduser('~/.GarminDb/garth_session'),'w').write(garth.client.dumps()); \
+print('Fresh token saved')"
+```
+
+No token is required for the default transform-only path.
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_TYPE` | `duckdb` | `duckdb` or `postgres` |
+| `GARMIN_DOWNLOAD` | `false` | Run the live download phase first |
+| `GARMIN_DOWNLOAD_LATEST` | `true` | Incremental (`--latest`) vs. full download |
+| `GARMIN_DOWNLOAD_REQUIRED` | `true` | Abort if a required download fails (vs. fall back to existing DBs) |
+| `GARMIN_DB_DIR` | `local_data/garmin_sqlite/DBs` | GarminDB SQLite directory |
+| `GARMIN_BASE_DIR` | `local_data/garmin_sqlite` | GarminDB base dir (download phase) |
+| `GARMIN_DUCKDB_PATH` | `local_data/garmin.duckdb` | DuckDB output file |
+| `GARMIN_CONFIG_DIR` | `local_data/.GarminDb` | Download-phase config + token dir |
+| `POSTGRES_*` | — | PostgreSQL connection (when `DATABASE_TYPE=postgres`) |
+
+## Related
+
+- GarminDB upstream: `../../garmin/GarminDB-notebooks/`
+- Polar import job (sibling pattern): `../import/`
+- Query notebook: `notebooks/query_garmin_duckdb.md`

--- a/jobs/import-garmin/docker-compose.yml
+++ b/jobs/import-garmin/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  import-garmin:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: garmin-import-job
+    env_file:
+      - .env
+    volumes:
+      # DuckDB output + GarminDB SQLite input live under local_data.
+      - ./local_data:/app/local_data
+      # Only needed when GARMIN_DOWNLOAD=true: mount the garth session + config.
+      # The download phase writes its own GarminConnectConfig.json under
+      # local_data/.GarminDb and reuses the garth_session token found there or
+      # copied from this mount.
+      - ~/.GarminDb:/root/.GarminDb
+    environment:
+      - IN_CONTAINER=true

--- a/jobs/import-garmin/garmin_etl/__init__.py
+++ b/jobs/import-garmin/garmin_etl/__init__.py
@@ -1,0 +1,6 @@
+"""Garmin ETL package: transform GarminDB SQLite data into DuckDB / PostgreSQL.
+
+Exposes a configuration loader, a transform layer that reads the GarminDB SQLite
+databases, an optional download layer (GarminDB CLI), and two storage backends
+(DuckDB and PostgreSQL) selectable via the ``DATABASE_TYPE`` environment variable.
+"""

--- a/jobs/import-garmin/garmin_etl/config.py
+++ b/jobs/import-garmin/garmin_etl/config.py
@@ -1,0 +1,164 @@
+"""Configuration loading for the Garmin import job.
+
+All configuration is read from environment variables (optionally via a ``.env``
+file). Relative paths are resolved against the job directory (the parent of this
+package) so the job behaves identically whether it is launched from the repo
+root, the job folder, or inside the Docker container (WORKDIR ``/app``).
+
+Key switches
+------------
+- ``DATABASE_TYPE``    : ``duckdb`` (default) or ``postgres`` — selects the layer.
+- ``GARMIN_DOWNLOAD``  : ``true`` to run the optional GarminDB download phase.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict
+
+
+def _resolve(base_dir: Path, value: str) -> Path:
+    """Resolve a possibly-relative path against ``base_dir``."""
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = base_dir / path
+    return path
+
+
+def load_garmin_configuration() -> Dict[str, object]:
+    """Load Garmin import job configuration from environment variables.
+
+    Returns
+    -------
+    dict
+        Configuration values consumed by the transform / storage layers.
+
+    Raises
+    ------
+    ValueError
+        If ``DATABASE_TYPE`` is invalid, or PostgreSQL settings are incomplete
+        when ``DATABASE_TYPE='postgres'``.
+    """
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+    except ImportError:
+        pass
+
+    # Job directory = parent of the garmin_etl package directory.
+    job_dir = Path(__file__).resolve().parent.parent
+
+    # ── Database backend switch ─────────────────────────────────────────────
+    database_type = os.getenv("DATABASE_TYPE", "duckdb").lower()
+    if database_type not in ("duckdb", "postgres"):
+        raise ValueError(
+            f"Invalid DATABASE_TYPE '{database_type}'. Must be 'duckdb' or 'postgres'."
+        )
+
+    # ── Download toggle ─────────────────────────────────────────────────────
+    garmin_download = os.getenv("GARMIN_DOWNLOAD", "false").lower() == "true"
+    garmin_download_latest = os.getenv("GARMIN_DOWNLOAD_LATEST", "true").lower() == "true"
+    # When the download phase is required, a download failure aborts the job
+    # instead of silently falling back to existing (stale) SQLite databases.
+    garmin_download_required = os.getenv("GARMIN_DOWNLOAD_REQUIRED", "true").lower() == "true"
+
+    # ── Paths ───────────────────────────────────────────────────────────────
+    # Directory containing the GarminDB SQLite databases
+    # (garmin_activities.db, garmin.db).
+    garmin_db_dir = _resolve(
+        job_dir, os.getenv("GARMIN_DB_DIR", "local_data/garmin_sqlite/DBs")
+    )
+
+    # Dedicated DuckDB output file (does NOT clobber Polar's database_v2.duckdb).
+    garmin_duckdb_path = _resolve(
+        job_dir, os.getenv("GARMIN_DUCKDB_PATH", "local_data/garmin.duckdb")
+    )
+
+    # GarminDB base dir (used by the optional download phase). Its DBs land in
+    # ``<base>/DBs`` which should match ``GARMIN_DB_DIR``.
+    garmin_base_dir = _resolve(
+        job_dir, os.getenv("GARMIN_BASE_DIR", "local_data/garmin_sqlite")
+    )
+
+    # GarminDB config dir (holds GarminConnectConfig.json + garth_session).
+    garmin_config_dir_env = os.getenv("GARMIN_CONFIG_DIR")
+    garmin_config_dir = (
+        _resolve(job_dir, garmin_config_dir_env) if garmin_config_dir_env else None
+    )
+
+    # Timezone used only as future correlation metadata (timestamps are stored
+    # as local-naive wall clock values, not localized).
+    garmin_local_timezone = os.getenv("GARMIN_LOCAL_TIMEZONE", "UTC")
+
+    # ── PostgreSQL configuration ────────────────────────────────────────────
+    postgres_connection_string = os.getenv("POSTGRES_CONNECTION_STRING")
+    postgres_host = os.getenv("POSTGRES_HOST")
+    postgres_port = os.getenv("POSTGRES_PORT", "5432")
+    postgres_database = os.getenv("POSTGRES_DATABASE", "workoutdata")
+    postgres_user = os.getenv("POSTGRES_USER")
+    postgres_password = os.getenv("POSTGRES_PASSWORD")
+    postgres_sslmode = os.getenv("POSTGRES_SSLMODE", "prefer")
+
+    if database_type == "postgres" and not postgres_connection_string:
+        missing = [
+            name
+            for name, val in (
+                ("POSTGRES_HOST", postgres_host),
+                ("POSTGRES_DATABASE", postgres_database),
+                ("POSTGRES_USER", postgres_user),
+                ("POSTGRES_PASSWORD", postgres_password),
+            )
+            if not val
+        ]
+        if missing:
+            raise ValueError(
+                "DATABASE_TYPE is 'postgres' but missing required configuration. "
+                f"Provide POSTGRES_CONNECTION_STRING or all of: {', '.join(missing)}"
+            )
+
+    # ── Azure Storage (optional) ────────────────────────────────────────────
+    azure_storage_enabled = os.getenv("AZURE_STORAGE_ENABLED", "false").lower() == "true"
+    azure_storage_account_name = os.getenv("AZURE_STORAGE_ACCOUNT_NAME")
+    azure_storage_container_name = os.getenv("AZURE_STORAGE_CONTAINER_NAME", "workout-data")
+
+    config: Dict[str, object] = {
+        "JOB_DIR": job_dir,
+        "DATABASE_TYPE": database_type,
+        "GARMIN_DOWNLOAD": garmin_download,
+        "GARMIN_DOWNLOAD_LATEST": garmin_download_latest,
+        "GARMIN_DOWNLOAD_REQUIRED": garmin_download_required,
+        "GARMIN_DB_DIR": garmin_db_dir,
+        "GARMIN_DUCKDB_PATH": garmin_duckdb_path,
+        "GARMIN_BASE_DIR": garmin_base_dir,
+        "GARMIN_CONFIG_DIR": garmin_config_dir,
+        "GARMIN_LOCAL_TIMEZONE": garmin_local_timezone,
+        "POSTGRES_CONNECTION_STRING": postgres_connection_string,
+        "POSTGRES_HOST": postgres_host,
+        "POSTGRES_PORT": postgres_port,
+        "POSTGRES_DATABASE": postgres_database,
+        "POSTGRES_USER": postgres_user,
+        "POSTGRES_PASSWORD": postgres_password,
+        "POSTGRES_SSLMODE": postgres_sslmode,
+        "AZURE_STORAGE_ENABLED": azure_storage_enabled,
+        "AZURE_STORAGE_ACCOUNT_NAME": azure_storage_account_name,
+        "AZURE_STORAGE_CONTAINER_NAME": azure_storage_container_name,
+    }
+
+    print("✅ Garmin configuration loaded")
+    print(f"  - Database type: {database_type.upper()}")
+    print(f"  - Download phase: {'enabled' if garmin_download else 'disabled (transform-only)'}")
+    print(f"  - Garmin SQLite dir: {garmin_db_dir}")
+    if database_type == "duckdb":
+        print(f"  - DuckDB path: {garmin_duckdb_path}")
+    else:
+        if postgres_connection_string:
+            print("  - PostgreSQL: via connection string")
+        else:
+            print(f"  - PostgreSQL: {postgres_host}:{postgres_port}/{postgres_database}")
+    print(f"  - Azure Storage: {'enabled' if azure_storage_enabled else 'disabled'}")
+
+    return config
+
+
+__all__ = ["load_garmin_configuration"]

--- a/jobs/import-garmin/garmin_etl/download.py
+++ b/jobs/import-garmin/garmin_etl/download.py
@@ -1,0 +1,239 @@
+"""Optional download phase: refresh GarminDB SQLite via the GarminDB CLI.
+
+Runs only when ``GARMIN_DOWNLOAD=true``. It writes a job-controlled
+``GarminConnectConfig.json`` (with ``base_dir`` pinned to the mounted Garmin
+base directory and ``metric=true``), ensures a ``garth_session`` token is
+available, and invokes ``garmindb_cli.py -f <config_dir> --all --download
+--import`` so the SQLite databases are rebuilt in place.
+
+``garmindb`` is imported lazily / only required here, so the default
+transform-only path has no dependency on it. This phase is best-effort: callers
+should fall back to existing SQLite databases on failure.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_CONFIG_DIRNAME = ".GarminDb"
+
+
+def _build_garmin_config(config: dict) -> dict:
+    """Construct a GarminConnectConfig.json dict pinned to the job's paths."""
+    base_dir = str(Path(config["GARMIN_BASE_DIR"]).resolve())
+    start_date = os.getenv("GARMIN_START_DATE", "01/01/2020")
+    all_activities = int(os.getenv("GARMIN_DOWNLOAD_ALL_ACTIVITIES", "1000"))
+    latest_activities = int(os.getenv("GARMIN_DOWNLOAD_LATEST_ACTIVITIES", "25"))
+    domain = os.getenv("GARMIN_DOMAIN", "garmin.com")
+
+    return {
+        "db": {"type": "sqlite"},
+        "garmin": {"domain": domain},
+        "credentials": {
+            "user": os.getenv("GARMIN_USER", ""),
+            "secure_password": False,
+            "password": os.getenv("GARMIN_PASSWORD", ""),
+            "password_file": None,
+        },
+        "data": {
+            "weight_start_date": start_date,
+            "sleep_start_date": start_date,
+            "rhr_start_date": start_date,
+            "hrv_start_date": start_date,
+            "monitoring_start_date": start_date,
+            "download_latest_activities": latest_activities,
+            "download_all_activities": all_activities,
+        },
+        "directories": {
+            "relative_to_home": False,
+            "base_dir": base_dir,
+            "mount_dir": "/Volumes/GARMIN",
+        },
+        "enabled_stats": {
+            "monitoring": False,
+            "steps": False,
+            "itime": False,
+            "sleep": True,
+            "rhr": False,
+            "hrv": False,
+            "weight": False,
+            "activities": True,
+        },
+        "course_views": {"steps": []},
+        "modes": {},
+        "activities": {"display": []},
+        "settings": {
+            "metric": True,
+            "default_display_activities": ["walking", "running", "cycling"],
+        },
+        "checkup": {"look_back_days": 90},
+    }
+
+
+def _resolve_config_dir(config: dict) -> Path:
+    config_dir = config.get("GARMIN_CONFIG_DIR")
+    if config_dir:
+        return Path(config_dir)
+    return Path(config["JOB_DIR"]) / "local_data" / DEFAULT_CONFIG_DIRNAME
+
+
+def _read_session_token(session_file: Path):
+    """Parse a garth_session token (base64-encoded JSON). Returns obj or None."""
+    import base64
+
+    try:
+        return json.loads(base64.b64decode(session_file.read_text()))
+    except Exception:
+        return None
+
+
+def _validate_session_token(session_file: Path) -> None:
+    """Fail fast if the garth session's refresh token is already expired.
+
+    garth can refresh an expired *access* token, but once the *refresh* token
+    expires a full interactive re-login (with MFA) is required — which cannot
+    happen inside the container. Detect that up front with a clear message.
+    """
+    import time
+
+    obj = _read_session_token(session_file)
+    if obj is None:
+        return  # Unknown format — let the CLI surface any problem.
+
+    oauth2 = None
+    candidates = obj if isinstance(obj, list) else [obj]
+    for item in candidates:
+        if isinstance(item, dict) and "refresh_token_expires_at" in item:
+            oauth2 = item
+            break
+    if not oauth2:
+        return
+
+    now = time.time()
+    refresh_exp = oauth2.get("refresh_token_expires_at")
+    if refresh_exp and now > refresh_exp:
+        from datetime import datetime
+
+        expired_on = datetime.fromtimestamp(refresh_exp).strftime("%Y-%m-%d %H:%M:%S")
+        raise RuntimeError(
+            f"Garmin garth session is expired (refresh token expired {expired_on}). "
+            "Generate a new token on the host with './scripts/renew_garmin_token.sh' (prompts "
+            "for Garmin login + MFA and writes ~/.GarminDb/garth_session), then re-run "
+            f"this job. Token file: {session_file}"
+        )
+
+
+def _ensure_session_token(config_dir: Path) -> Path:
+    """Ensure a garth_session token exists in the config dir; return its path.
+
+    The host token (``~/.GarminDb/garth_session``) is the source of truth: when it
+    exists, the config-dir copy is **refreshed** from it on every run so a freshly
+    renewed token is always used (a stale cached copy in the config dir — e.g. left
+    by a previous run on the mounted volume — must never win).
+    """
+    session_file = config_dir / "garth_session"
+    host_session = Path(os.path.expanduser("~")) / ".GarminDb" / "garth_session"
+
+    if host_session.exists() and host_session.resolve() != session_file.resolve():
+        shutil.copy2(host_session, session_file)
+        print(f"  Refreshed garth_session from {host_session}")
+        return session_file
+
+    if session_file.exists():
+        return session_file
+
+    raise FileNotFoundError(
+        "No garth_session token found. Generate one with the helper script on the "
+        f"host: './scripts/renew_garmin_token.sh' (writes ~/.GarminDb/garth_session), or place "
+        f"a valid token at {session_file}."
+    )
+
+
+def _find_cli() -> list:
+    """Return the command prefix used to invoke garmindb_cli."""
+    cli = shutil.which("garmindb_cli.py")
+    if cli:
+        return [sys.executable, cli]
+    # Fall back to the module form if the package exposes it.
+    return [sys.executable, "-m", "garmindb.garmindb_cli"]
+
+
+# garmindb_cli.py exits 0 even when authentication fails, so the textual output
+# must be scanned for these failure markers.
+_FAILURE_MARKERS = (
+    "Failed to login",
+    "Login failed",
+    "Authentication failed",
+    "Failed to authenticate",
+    "session expired",
+    "401 Client Error",
+    "403 Client Error",
+)
+
+
+def run_download(config: dict) -> bool:
+    """Run the GarminDB download+import phase. Returns True on success.
+
+    Raises on misconfiguration (missing/expired token). Returns False if the CLI
+    fails (non-zero exit OR an authentication failure marker in its output), so
+    the caller can decide whether to abort or fall back to existing databases.
+    """
+    try:
+        import garmindb  # noqa: F401  (presence check; lazy)
+    except ImportError as exc:
+        raise ImportError(
+            "GARMIN_DOWNLOAD is enabled but the 'garmindb' package is not installed. "
+            "Install it with: pip install garmindb"
+        ) from exc
+
+    config_dir = _resolve_config_dir(config)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    Path(config["GARMIN_BASE_DIR"]).mkdir(parents=True, exist_ok=True)
+
+    config_file = config_dir / "GarminConnectConfig.json"
+    config_file.write_text(json.dumps(_build_garmin_config(config), indent=4), encoding="utf-8")
+    print(f"  Wrote GarminDB config: {config_file}")
+
+    session_file = _ensure_session_token(config_dir)
+    _validate_session_token(session_file)  # fail fast on an expired refresh token
+
+    cmd = _find_cli() + ["-f", str(config_dir), "--all", "--download", "--import"]
+    if config.get("GARMIN_DOWNLOAD_LATEST", True):
+        cmd.append("--latest")
+
+    print(f"  Running: {' '.join(cmd)}")
+    # Stream output live while capturing it so we can detect auth failures that
+    # garmindb_cli does not surface via the exit code.
+    captured = []
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
+    )
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        captured.append(line)
+    returncode = proc.wait()
+    output = "".join(captured)
+
+    failure_marker = next((m for m in _FAILURE_MARKERS if m.lower() in output.lower()), None)
+    if returncode != 0:
+        print(f"  ❌ garmindb_cli exited with code {returncode}")
+        return False
+    if failure_marker:
+        print(
+            f"  ❌ GarminDB download failed: detected '{failure_marker}' in CLI output "
+            "(garmindb_cli returns 0 even on auth failure). The garth session is likely "
+            "expired — regenerate it (Garmin login + MFA) and re-run."
+        )
+        return False
+
+    print("  ✅ GarminDB download + import complete")
+    return True
+
+
+__all__ = ["run_download"]

--- a/jobs/import-garmin/garmin_etl/storage/__init__.py
+++ b/jobs/import-garmin/garmin_etl/storage/__init__.py
@@ -1,0 +1,8 @@
+"""Storage backends for Garmin data.
+
+Two interchangeable data layers expose the same surface:
+- ``garmin_etl.storage.duckdb``
+- ``garmin_etl.storage.postgres``
+
+The active backend is chosen at runtime via ``config['DATABASE_TYPE']``.
+"""

--- a/jobs/import-garmin/garmin_etl/storage/duckdb.py
+++ b/jobs/import-garmin/garmin_etl/storage/duckdb.py
@@ -1,0 +1,265 @@
+"""DuckDB storage backend for Garmin data.
+
+Writes three ``garmin_``-prefixed tables into a dedicated DuckDB file (kept
+separate from Polar's ``database_v2.duckdb``):
+
+- ``garmin_workout_metadata`` (PK ``activity_id``; carries ``workoutId`` + GPS)
+- ``garmin_timeseries``       (PK ``activity_id, record``; per-second HR/GPS)
+- ``garmin_sleep``            (PK ``day``)
+
+Tables use **explicit DDL**. Imports are idempotent via delete-by-id upsert.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import duckdb  # type: ignore
+import pandas as pd  # type: ignore
+
+WORKOUT_METADATA_DDL = """
+CREATE TABLE IF NOT EXISTS garmin_workout_metadata (
+    activity_id      VARCHAR PRIMARY KEY,
+    workoutId        VARCHAR NOT NULL,
+    name             VARCHAR,
+    sport            VARCHAR,
+    sub_sport        VARCHAR,
+    start_time       TIMESTAMP,
+    stop_time        TIMESTAMP,
+    elapsed_time_s   INTEGER,
+    moving_time_s    INTEGER,
+    distance         DOUBLE,
+    calories         INTEGER,
+    avg_hr           INTEGER,
+    max_hr           INTEGER,
+    avg_speed        DOUBLE,
+    max_speed        DOUBLE,
+    avg_cadence      INTEGER,
+    ascent           DOUBLE,
+    descent          DOUBLE,
+    training_load    DOUBLE,
+    training_effect  DOUBLE,
+    gps_lat          DOUBLE,
+    gps_long         DOUBLE,
+    gps_source       VARCHAR
+);
+"""
+
+TIMESERIES_DDL = """
+CREATE TABLE IF NOT EXISTS garmin_timeseries (
+    activity_id    VARCHAR NOT NULL,
+    workoutId      VARCHAR,
+    record         INTEGER NOT NULL,
+    timestamp      TIMESTAMP,
+    hr             INTEGER,
+    position_lat   DOUBLE,
+    position_long  DOUBLE,
+    speed          DOUBLE,
+    distance       DOUBLE,
+    cadence        INTEGER,
+    altitude       DOUBLE,
+    temperature    DOUBLE,
+    rr             DOUBLE,
+    PRIMARY KEY (activity_id, record)
+);
+"""
+
+SLEEP_DDL = """
+CREATE TABLE IF NOT EXISTS garmin_sleep (
+    day            DATE PRIMARY KEY,
+    sleep_start    TIMESTAMP,
+    sleep_end      TIMESTAMP,
+    total_sleep_s  INTEGER,
+    deep_sleep_s   INTEGER,
+    light_sleep_s  INTEGER,
+    rem_sleep_s    INTEGER,
+    awake_s        INTEGER,
+    avg_spo2       DOUBLE,
+    avg_rr         DOUBLE,
+    avg_stress     DOUBLE,
+    score          INTEGER,
+    qualifier      VARCHAR
+);
+"""
+
+
+def _connect(config: dict) -> duckdb.DuckDBPyConnection:
+    db_path = Path(config["GARMIN_DUCKDB_PATH"])
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    return duckdb.connect(str(db_path))
+
+
+def ensure_tables(config: dict) -> None:
+    """Create the Garmin tables if they do not already exist."""
+    con = _connect(config)
+    try:
+        con.execute(WORKOUT_METADATA_DDL)
+        con.execute(TIMESERIES_DDL)
+        con.execute(SLEEP_DDL)
+    finally:
+        con.close()
+
+
+def import_workouts(
+    workouts_df: pd.DataFrame, timeseries_df: pd.DataFrame, config: dict
+) -> dict:
+    """Upsert workout metadata + per-second timeseries (idempotent by activity_id)."""
+    con = _connect(config)
+    try:
+        con.execute(WORKOUT_METADATA_DDL)
+        con.execute(TIMESERIES_DDL)
+        con.register("workouts_view", workouts_df)
+        con.register("timeseries_view", timeseries_df)
+
+        con.execute("BEGIN TRANSACTION")
+        try:
+            con.execute(
+                "DELETE FROM garmin_timeseries WHERE activity_id IN "
+                "(SELECT DISTINCT activity_id FROM timeseries_view)"
+            )
+            con.execute(
+                "DELETE FROM garmin_workout_metadata WHERE activity_id IN "
+                "(SELECT activity_id FROM workouts_view)"
+            )
+            con.execute("INSERT INTO garmin_workout_metadata BY NAME SELECT * FROM workouts_view")
+            con.execute("INSERT INTO garmin_timeseries BY NAME SELECT * FROM timeseries_view")
+            con.execute("COMMIT")
+        except Exception:
+            try:
+                con.execute("ROLLBACK")
+            except Exception:
+                pass  # Preserve the original exception
+            raise
+
+        meta_count = con.execute("SELECT COUNT(*) FROM garmin_workout_metadata").fetchone()[0]
+        ts_count = con.execute("SELECT COUNT(*) FROM garmin_timeseries").fetchone()[0]
+        print(
+            f"  ✅ DuckDB workouts: upserted {len(workouts_df)} "
+            f"(table total {meta_count}); timeseries rows {len(timeseries_df)} "
+            f"(table total {ts_count})"
+        )
+        return {"workouts": meta_count, "timeseries": ts_count}
+    finally:
+        con.close()
+
+
+def import_sleep(sleep_df: pd.DataFrame, config: dict) -> dict:
+    """Upsert daily sleep rows (idempotent by day)."""
+    con = _connect(config)
+    try:
+        con.execute(SLEEP_DDL)
+        if sleep_df.empty:
+            count = con.execute("SELECT COUNT(*) FROM garmin_sleep").fetchone()[0]
+            print("  ℹ️  No sleep rows to import")
+            return {"sleep": count}
+
+        con.register("sleep_view", sleep_df)
+        con.execute("BEGIN TRANSACTION")
+        try:
+            con.execute(
+                "DELETE FROM garmin_sleep WHERE day IN "
+                "(SELECT CAST(day AS DATE) FROM sleep_view)"
+            )
+            con.execute("INSERT INTO garmin_sleep BY NAME SELECT * FROM sleep_view")
+            con.execute("COMMIT")
+        except Exception:
+            try:
+                con.execute("ROLLBACK")
+            except Exception:
+                pass  # Preserve the original exception
+            raise
+
+        count = con.execute("SELECT COUNT(*) FROM garmin_sleep").fetchone()[0]
+        print(f"  ✅ DuckDB sleep: upserted {len(sleep_df)} (table total {count})")
+        return {"sleep": count}
+    finally:
+        con.close()
+
+
+# =============================================================================
+# Query helpers
+# =============================================================================
+
+def get_existing_activity_ids(config: dict) -> set:
+    """Return the set of activity_ids already present in workout metadata."""
+    con = _connect(config)
+    try:
+        exists = con.execute(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = 'garmin_workout_metadata'"
+        ).fetchone()
+        if not exists:
+            return set()
+        rows = con.execute("SELECT activity_id FROM garmin_workout_metadata").fetchall()
+        return {r[0] for r in rows}
+    finally:
+        con.close()
+
+
+def get_garmin_workout_metadata(config: dict, workout_ids: Optional[list] = None) -> pd.DataFrame:
+    """Return workout metadata, optionally filtered by ``workoutId`` values."""
+    con = _connect(config)
+    try:
+        if workout_ids:
+            placeholders = ", ".join("?" for _ in workout_ids)
+            return con.execute(
+                f"SELECT * FROM garmin_workout_metadata WHERE workoutId IN ({placeholders}) "
+                "ORDER BY start_time",
+                workout_ids,
+            ).fetchdf()
+        return con.execute(
+            "SELECT * FROM garmin_workout_metadata ORDER BY start_time"
+        ).fetchdf()
+    finally:
+        con.close()
+
+
+def get_garmin_timeseries(workout_ids: list, config: dict) -> pd.DataFrame:
+    """Return per-second timeseries for the given ``workoutId`` values."""
+    if not workout_ids:
+        return pd.DataFrame()
+    con = _connect(config)
+    try:
+        placeholders = ", ".join("?" for _ in workout_ids)
+        return con.execute(
+            f"SELECT * FROM garmin_timeseries WHERE workoutId IN ({placeholders}) "
+            "ORDER BY workoutId, record",
+            workout_ids,
+        ).fetchdf()
+    finally:
+        con.close()
+
+
+def get_garmin_sleep(config: dict) -> pd.DataFrame:
+    """Return all daily sleep rows ordered by day."""
+    con = _connect(config)
+    try:
+        return con.execute("SELECT * FROM garmin_sleep ORDER BY day").fetchdf()
+    finally:
+        con.close()
+
+
+def delete_workout_by_id(activity_id: str, config: dict) -> None:
+    """Delete a workout (metadata + timeseries) by ``activity_id``."""
+    con = _connect(config)
+    try:
+        con.execute(
+            "DELETE FROM garmin_timeseries WHERE activity_id = ?", (activity_id,)
+        )
+        con.execute(
+            "DELETE FROM garmin_workout_metadata WHERE activity_id = ?", (activity_id,)
+        )
+        print(f"Deleted activity_id = '{activity_id}'")
+    finally:
+        con.close()
+
+
+__all__ = [
+    "ensure_tables",
+    "import_workouts",
+    "import_sleep",
+    "get_existing_activity_ids",
+    "get_garmin_workout_metadata",
+    "get_garmin_timeseries",
+    "get_garmin_sleep",
+    "delete_workout_by_id",
+]

--- a/jobs/import-garmin/garmin_etl/storage/postgres.py
+++ b/jobs/import-garmin/garmin_etl/storage/postgres.py
@@ -1,0 +1,354 @@
+"""PostgreSQL storage backend for Garmin data.
+
+Mirrors :mod:`garmin_etl.storage.duckdb` for PostgreSQL using ``psycopg`` (v3).
+Creates three ``garmin_``-prefixed tables with explicit DDL and performs
+idempotent delete-by-id upserts. Nullable integers are bound as ``None`` (never
+``NaN``) so PostgreSQL integer columns accept them.
+"""
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+import psycopg  # type: ignore
+
+from garmin_etl.transform import (
+    SLEEP_COLUMNS,
+    TIMESERIES_COLUMNS,
+    WORKOUT_COLUMNS,
+)
+
+WORKOUT_METADATA_DDL = """
+CREATE TABLE IF NOT EXISTS garmin_workout_metadata (
+    activity_id      TEXT PRIMARY KEY,
+    "workoutId"      TEXT NOT NULL,
+    name             TEXT,
+    sport            TEXT,
+    sub_sport        TEXT,
+    start_time       TIMESTAMP,
+    stop_time        TIMESTAMP,
+    elapsed_time_s   INTEGER,
+    moving_time_s    INTEGER,
+    distance         DOUBLE PRECISION,
+    calories         INTEGER,
+    avg_hr           INTEGER,
+    max_hr           INTEGER,
+    avg_speed        DOUBLE PRECISION,
+    max_speed        DOUBLE PRECISION,
+    avg_cadence      INTEGER,
+    ascent           DOUBLE PRECISION,
+    descent          DOUBLE PRECISION,
+    training_load    DOUBLE PRECISION,
+    training_effect  DOUBLE PRECISION,
+    gps_lat          DOUBLE PRECISION,
+    gps_long         DOUBLE PRECISION,
+    gps_source       TEXT
+);
+"""
+
+TIMESERIES_DDL = """
+CREATE TABLE IF NOT EXISTS garmin_timeseries (
+    activity_id    TEXT NOT NULL,
+    "workoutId"    TEXT,
+    record         INTEGER NOT NULL,
+    "timestamp"    TIMESTAMP,
+    hr             INTEGER,
+    position_lat   DOUBLE PRECISION,
+    position_long  DOUBLE PRECISION,
+    speed          DOUBLE PRECISION,
+    distance       DOUBLE PRECISION,
+    cadence        INTEGER,
+    altitude       DOUBLE PRECISION,
+    temperature    DOUBLE PRECISION,
+    rr             DOUBLE PRECISION,
+    PRIMARY KEY (activity_id, record)
+);
+"""
+
+SLEEP_DDL = """
+CREATE TABLE IF NOT EXISTS garmin_sleep (
+    day            DATE PRIMARY KEY,
+    sleep_start    TIMESTAMP,
+    sleep_end      TIMESTAMP,
+    total_sleep_s  INTEGER,
+    deep_sleep_s   INTEGER,
+    light_sleep_s  INTEGER,
+    rem_sleep_s    INTEGER,
+    awake_s        INTEGER,
+    avg_spo2       DOUBLE PRECISION,
+    avg_rr         DOUBLE PRECISION,
+    avg_stress     DOUBLE PRECISION,
+    score          INTEGER,
+    qualifier      TEXT
+);
+"""
+
+
+def get_postgres_connection(config: dict):
+    """Open a PostgreSQL connection from configuration."""
+    if config is None:
+        raise ValueError("config parameter is required and cannot be None")
+
+    conn_string = config.get("POSTGRES_CONNECTION_STRING")
+    if conn_string:
+        return psycopg.connect(conn_string)
+
+    host = config.get("POSTGRES_HOST")
+    port = config.get("POSTGRES_PORT", 5432)
+    database = config.get("POSTGRES_DATABASE")
+    user = config.get("POSTGRES_USER")
+    password = config.get("POSTGRES_PASSWORD")
+    sslmode = config.get("POSTGRES_SSLMODE", "prefer")
+
+    if not all([host, database, user, password]):
+        raise ValueError(
+            "Missing required PostgreSQL configuration. Provide POSTGRES_CONNECTION_STRING "
+            "or all of: POSTGRES_HOST, POSTGRES_DATABASE, POSTGRES_USER, POSTGRES_PASSWORD"
+        )
+
+    return psycopg.connect(
+        host=host, port=port, dbname=database, user=user, password=password, sslmode=sslmode
+    )
+
+
+def _to_py(value):
+    """Convert a pandas/numpy scalar to a native Python value (NA/NaN/NaT → None)."""
+    if value is None:
+        return None
+    if value is pd.NaT or value is pd.NA:
+        return None
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    if isinstance(value, pd.Timestamp):
+        return value.to_pydatetime()
+    if isinstance(value, np.datetime64):
+        ts = pd.Timestamp(value)
+        return None if ts is pd.NaT else ts.to_pydatetime()
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _prepare_rows(df: pd.DataFrame, columns: list) -> list:
+    """Build a list of native-Python row tuples in ``columns`` order."""
+    ordered = df[columns]
+    return [tuple(_to_py(v) for v in row) for row in ordered.itertuples(index=False, name=None)]
+
+
+def _quoted(columns: list) -> str:
+    return ", ".join(f'"{c}"' for c in columns)
+
+
+def _insert_sql(table: str, columns: list) -> str:
+    cols = _quoted(columns)
+    placeholders = ", ".join(["%s"] * len(columns))
+    return f"INSERT INTO {table} ({cols}) VALUES ({placeholders})"
+
+
+def ensure_tables(config: dict) -> None:
+    """Create the Garmin tables if they do not already exist."""
+    conn = get_postgres_connection(config)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(WORKOUT_METADATA_DDL)
+            cur.execute(TIMESERIES_DDL)
+            cur.execute(SLEEP_DDL)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def import_workouts(
+    workouts_df: pd.DataFrame, timeseries_df: pd.DataFrame, config: dict
+) -> dict:
+    """Upsert workout metadata + per-second timeseries (idempotent by activity_id)."""
+    conn = get_postgres_connection(config)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(WORKOUT_METADATA_DDL)
+            cur.execute(TIMESERIES_DDL)
+
+            activity_ids = [str(a) for a in workouts_df["activity_id"].tolist()]
+            ts_activity_ids = [
+                str(a) for a in timeseries_df["activity_id"].dropna().unique().tolist()
+            ]
+
+            if ts_activity_ids:
+                cur.execute(
+                    "DELETE FROM garmin_timeseries WHERE activity_id = ANY(%s)",
+                    (ts_activity_ids,),
+                )
+            if activity_ids:
+                cur.execute(
+                    "DELETE FROM garmin_workout_metadata WHERE activity_id = ANY(%s)",
+                    (activity_ids,),
+                )
+
+            cur.executemany(
+                _insert_sql("garmin_workout_metadata", WORKOUT_COLUMNS),
+                _prepare_rows(workouts_df, WORKOUT_COLUMNS),
+            )
+            cur.executemany(
+                _insert_sql("garmin_timeseries", TIMESERIES_COLUMNS),
+                _prepare_rows(timeseries_df, TIMESERIES_COLUMNS),
+            )
+
+            cur.execute("SELECT COUNT(*) FROM garmin_workout_metadata")
+            meta_count = cur.fetchone()[0]
+            cur.execute("SELECT COUNT(*) FROM garmin_timeseries")
+            ts_count = cur.fetchone()[0]
+        conn.commit()
+        print(
+            f"  ✅ PostgreSQL workouts: upserted {len(workouts_df)} "
+            f"(table total {meta_count}); timeseries rows {len(timeseries_df)} "
+            f"(table total {ts_count})"
+        )
+        return {"workouts": meta_count, "timeseries": ts_count}
+    except Exception:
+        try:
+            conn.rollback()
+        except Exception:
+            pass  # Preserve the original exception
+        raise
+    finally:
+        conn.close()
+
+
+def import_sleep(sleep_df: pd.DataFrame, config: dict) -> dict:
+    """Upsert daily sleep rows (idempotent by day)."""
+    conn = get_postgres_connection(config)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(SLEEP_DDL)
+            if sleep_df.empty:
+                cur.execute("SELECT COUNT(*) FROM garmin_sleep")
+                count = cur.fetchone()[0]
+                conn.commit()
+                print("  ℹ️  No sleep rows to import")
+                return {"sleep": count}
+
+            days = [_to_py(d) for d in sleep_df["day"].tolist()]
+            days = [d.date() if hasattr(d, "date") else d for d in days if d is not None]
+            if days:
+                cur.execute("DELETE FROM garmin_sleep WHERE day = ANY(%s)", (days,))
+
+            cur.executemany(
+                _insert_sql("garmin_sleep", SLEEP_COLUMNS),
+                _prepare_rows(sleep_df, SLEEP_COLUMNS),
+            )
+            cur.execute("SELECT COUNT(*) FROM garmin_sleep")
+            count = cur.fetchone()[0]
+        conn.commit()
+        print(f"  ✅ PostgreSQL sleep: upserted {len(sleep_df)} (table total {count})")
+        return {"sleep": count}
+    except Exception:
+        try:
+            conn.rollback()
+        except Exception:
+            pass  # Preserve the original exception
+        raise
+    finally:
+        conn.close()
+
+
+# =============================================================================
+# Query helpers
+# =============================================================================
+
+def get_existing_activity_ids(config: dict) -> set:
+    """Return the set of activity_ids already present in workout metadata."""
+    conn = get_postgres_connection(config)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT EXISTS (SELECT FROM information_schema.tables "
+                "WHERE table_name = 'garmin_workout_metadata')"
+            )
+            if not cur.fetchone()[0]:
+                return set()
+            cur.execute("SELECT activity_id FROM garmin_workout_metadata")
+            return {r[0] for r in cur.fetchall()}
+    finally:
+        conn.close()
+
+
+def get_garmin_workout_metadata(config: dict, workout_ids: Optional[list] = None) -> pd.DataFrame:
+    """Return workout metadata, optionally filtered by ``workoutId`` values."""
+    conn = get_postgres_connection(config)
+    try:
+        with conn.cursor() as cur:
+            if workout_ids:
+                cur.execute(
+                    'SELECT * FROM garmin_workout_metadata WHERE "workoutId" = ANY(%s) '
+                    "ORDER BY start_time",
+                    (list(workout_ids),),
+                )
+            else:
+                cur.execute("SELECT * FROM garmin_workout_metadata ORDER BY start_time")
+            cols = [d[0] for d in cur.description]
+            return pd.DataFrame(cur.fetchall(), columns=cols)
+    finally:
+        conn.close()
+
+
+def get_garmin_timeseries(workout_ids: list, config: dict) -> pd.DataFrame:
+    """Return per-second timeseries for the given ``workoutId`` values."""
+    if not workout_ids:
+        return pd.DataFrame()
+    conn = get_postgres_connection(config)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                'SELECT * FROM garmin_timeseries WHERE "workoutId" = ANY(%s) '
+                "ORDER BY \"workoutId\", record",
+                (list(workout_ids),),
+            )
+            cols = [d[0] for d in cur.description]
+            return pd.DataFrame(cur.fetchall(), columns=cols)
+    finally:
+        conn.close()
+
+
+def get_garmin_sleep(config: dict) -> pd.DataFrame:
+    """Return all daily sleep rows ordered by day."""
+    conn = get_postgres_connection(config)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT * FROM garmin_sleep ORDER BY day")
+            cols = [d[0] for d in cur.description]
+            return pd.DataFrame(cur.fetchall(), columns=cols)
+    finally:
+        conn.close()
+
+
+def delete_workout_by_id(activity_id: str, config: dict) -> None:
+    """Delete a workout (metadata + timeseries) by ``activity_id``."""
+    conn = get_postgres_connection(config)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM garmin_timeseries WHERE activity_id = %s", (activity_id,))
+            cur.execute("DELETE FROM garmin_workout_metadata WHERE activity_id = %s", (activity_id,))
+        conn.commit()
+        print(f"Deleted activity_id = '{activity_id}'")
+    finally:
+        conn.close()
+
+
+__all__ = [
+    "get_postgres_connection",
+    "ensure_tables",
+    "import_workouts",
+    "import_sleep",
+    "get_existing_activity_ids",
+    "get_garmin_workout_metadata",
+    "get_garmin_timeseries",
+    "get_garmin_sleep",
+    "delete_workout_by_id",
+]

--- a/jobs/import-garmin/garmin_etl/transform.py
+++ b/jobs/import-garmin/garmin_etl/transform.py
@@ -1,0 +1,386 @@
+"""Transform layer: read GarminDB SQLite databases into clean DataFrames.
+
+Reads the GarminDB-produced SQLite databases and returns three DataFrames with
+**explicit, stable dtypes** (so downstream DDL never depends on pandas type
+inference):
+
+- ``workouts``  : one row per activity (metadata) incl. derived ``workoutId``
+                  and the first valid GPS coordinate.
+- ``timeseries``: per-second activity records (carries ``workoutId`` linkage).
+- ``sleep``     : daily sleep summary.
+
+Source tables (GarminDB):
+- ``garmin_activities.db`` → ``activities``, ``activity_records``
+- ``garmin.db``           → ``sleep``
+
+Durations stored by GarminDB as ``HH:MM:SS[.ffffff]`` strings are converted to
+integer seconds. Timestamps are kept as local-naive wall-clock values.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Dict, Optional
+
+import pandas as pd  # type: ignore
+
+ACTIVITIES_DB = "garmin_activities.db"
+GARMIN_DB = "garmin.db"
+
+# Canonical output columns (also the DDL contract for the storage layers).
+WORKOUT_COLUMNS = [
+    "activity_id", "workoutId", "name", "sport", "sub_sport",
+    "start_time", "stop_time", "elapsed_time_s", "moving_time_s",
+    "distance", "calories", "avg_hr", "max_hr", "avg_speed", "max_speed",
+    "avg_cadence", "ascent", "descent", "training_load", "training_effect",
+    "gps_lat", "gps_long", "gps_source",
+]
+TIMESERIES_COLUMNS = [
+    "activity_id", "workoutId", "record", "timestamp", "hr",
+    "position_lat", "position_long", "speed", "distance", "cadence",
+    "altitude", "temperature", "rr",
+]
+SLEEP_COLUMNS = [
+    "day", "sleep_start", "sleep_end", "total_sleep_s", "deep_sleep_s",
+    "light_sleep_s", "rem_sleep_s", "awake_s", "avg_spo2", "avg_rr",
+    "avg_stress", "score", "qualifier",
+]
+
+# Integer-typed columns per frame (loaded as pandas nullable Int64).
+_WORKOUT_INT_COLS = [
+    "elapsed_time_s", "moving_time_s", "calories", "avg_hr", "max_hr", "avg_cadence",
+]
+_TIMESERIES_INT_COLS = ["record", "hr", "cadence"]
+_SLEEP_INT_COLS = [
+    "total_sleep_s", "deep_sleep_s", "light_sleep_s", "rem_sleep_s", "awake_s", "score",
+]
+
+
+# =============================================================================
+# Parsing helpers
+# =============================================================================
+
+def _duration_to_seconds(value) -> Optional[int]:
+    """Convert a GarminDB ``HH:MM:SS[.ffffff]`` duration to integer seconds."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or text.lower() in ("none", "nan", "nat"):
+        return None
+    try:
+        parts = text.split(":")
+        if len(parts) == 3:
+            hours, minutes, seconds = parts
+        elif len(parts) == 2:
+            hours, minutes, seconds = "0", parts[0], parts[1]
+        else:
+            return int(round(float(text)))
+        total = int(hours) * 3600 + int(minutes) * 60 + float(seconds)
+        return int(round(total))
+    except (ValueError, TypeError):
+        return None
+
+
+def _to_datetime(series: pd.Series) -> pd.Series:
+    """Parse a string column into local-naive datetimes (NaT on failure)."""
+    return pd.to_datetime(series, errors="coerce")
+
+
+def _build_workout_id(start_times: pd.Series) -> pd.Series:
+    """Build ``DD-MM-YYYY_HHMMSS`` ids from activity start datetimes."""
+    return start_times.dt.strftime("%d-%m-%Y_%H%M%S")
+
+
+def _is_valid_coord(lat, lon) -> bool:
+    """True only when both coordinates are present, in range, and not (0, 0)."""
+    if lat is None or lon is None:
+        return False
+    if pd.isna(lat) or pd.isna(lon):
+        return False
+    if not (-90.0 <= float(lat) <= 90.0) or not (-180.0 <= float(lon) <= 180.0):
+        return False
+    if float(lat) == 0.0 and float(lon) == 0.0:
+        return False
+    return True
+
+
+# =============================================================================
+# SQLite readers
+# =============================================================================
+
+def _connect_ro(db_path: Path) -> sqlite3.Connection:
+    """Open a SQLite database read-only with a busy timeout."""
+    uri = f"file:{db_path}?mode=ro"
+    return sqlite3.connect(uri, uri=True, timeout=30)
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def _read_activities(db_path: Path) -> pd.DataFrame:
+    conn = _connect_ro(db_path)
+    try:
+        if not _table_exists(conn, "activities"):
+            raise ValueError(f"Table 'activities' not found in {db_path}")
+        return pd.read_sql_query("SELECT * FROM activities", conn)
+    finally:
+        conn.close()
+
+
+def _read_activity_records(db_path: Path) -> pd.DataFrame:
+    conn = _connect_ro(db_path)
+    try:
+        if not _table_exists(conn, "activity_records"):
+            raise ValueError(f"Table 'activity_records' not found in {db_path}")
+        return pd.read_sql_query(
+            "SELECT * FROM activity_records ORDER BY activity_id, record", conn
+        )
+    finally:
+        conn.close()
+
+
+def _read_sleep(db_path: Path) -> pd.DataFrame:
+    conn = _connect_ro(db_path)
+    try:
+        if not _table_exists(conn, "sleep"):
+            raise ValueError(f"Table 'sleep' not found in {db_path}")
+        return pd.read_sql_query('SELECT * FROM sleep', conn)
+    finally:
+        conn.close()
+
+
+# =============================================================================
+# First-GPS computation
+# =============================================================================
+
+def _first_gps_by_activity(records_df: pd.DataFrame) -> Dict[str, tuple]:
+    """Return {activity_id: (lat, long)} for the first valid GPS fix.
+
+    "First" = lowest ``record`` (then ``timestamp``) where both coordinates are
+    valid. Activities without a valid fix are absent from the mapping.
+    """
+    if records_df.empty:
+        return {}
+
+    gps = records_df[["activity_id", "record", "timestamp", "position_lat", "position_long"]].copy()
+    gps = gps.sort_values(["activity_id", "record", "timestamp"])
+
+    result: Dict[str, tuple] = {}
+    for activity_id, group in gps.groupby("activity_id", sort=False):
+        for _, row in group.iterrows():
+            lat, lon = row["position_lat"], row["position_long"]
+            if _is_valid_coord(lat, lon):
+                result[str(activity_id)] = (float(lat), float(lon))
+                break
+    return result
+
+
+# =============================================================================
+# Frame builders
+# =============================================================================
+
+def _cast_int_cols(df: pd.DataFrame, columns: list) -> pd.DataFrame:
+    for col in columns:
+        if col in df.columns:
+            df[col] = pd.array(
+                pd.to_numeric(df[col], errors="coerce").round(), dtype="Int64"
+            )
+    return df
+
+
+def build_workout_metadata(
+    activities_df: pd.DataFrame, records_df: pd.DataFrame
+) -> pd.DataFrame:
+    """Build the ``garmin_workout_metadata`` frame (workoutId + first GPS)."""
+    df = activities_df.copy()
+    df["activity_id"] = df["activity_id"].astype(str)
+
+    df["start_time"] = _to_datetime(df.get("start_time"))
+    df["stop_time"] = _to_datetime(df.get("stop_time"))
+    df["workoutId"] = _build_workout_id(df["start_time"])
+
+    df["elapsed_time_s"] = df.get("elapsed_time").map(_duration_to_seconds)
+    df["moving_time_s"] = df.get("moving_time").map(_duration_to_seconds)
+
+    first_gps = _first_gps_by_activity(records_df)
+
+    def _gps_for(row):
+        aid = row["activity_id"]
+        if aid in first_gps:
+            lat, lon = first_gps[aid]
+            return pd.Series([lat, lon, "first_record"])
+        # Fallback to the activity-level start coordinate when valid.
+        slat, slon = row.get("start_lat"), row.get("start_long")
+        if _is_valid_coord(slat, slon):
+            return pd.Series([float(slat), float(slon), "activity_start"])
+        return pd.Series([None, None, "none"])
+
+    df[["gps_lat", "gps_long", "gps_source"]] = df.apply(_gps_for, axis=1)
+
+    # Ensure all output columns exist (some optional in older GarminDB schemas).
+    for col in WORKOUT_COLUMNS:
+        if col not in df.columns:
+            df[col] = None
+
+    df = df[WORKOUT_COLUMNS].copy()
+    df = _cast_int_cols(df, _WORKOUT_INT_COLS)
+    for col in ("distance", "avg_speed", "max_speed", "ascent", "descent",
+                "training_load", "training_effect", "gps_lat", "gps_long"):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    for col in ("activity_id", "workoutId", "name", "sport", "sub_sport", "gps_source"):
+        df[col] = df[col].astype(object).where(df[col].notna(), None)
+    return df.reset_index(drop=True)
+
+
+def build_timeseries(records_df: pd.DataFrame, workout_id_map: Dict[str, str]) -> pd.DataFrame:
+    """Build the ``garmin_timeseries`` frame, attaching ``workoutId``."""
+    df = records_df.copy()
+    df["activity_id"] = df["activity_id"].astype(str)
+    df["workoutId"] = df["activity_id"].map(workout_id_map)
+    df["timestamp"] = _to_datetime(df.get("timestamp"))
+
+    for col in TIMESERIES_COLUMNS:
+        if col not in df.columns:
+            df[col] = None
+
+    df = df[TIMESERIES_COLUMNS].copy()
+    df = _cast_int_cols(df, _TIMESERIES_INT_COLS)
+    for col in ("position_lat", "position_long", "speed", "distance",
+                "altitude", "temperature", "rr"):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    for col in ("activity_id", "workoutId"):
+        df[col] = df[col].astype(object).where(df[col].notna(), None)
+    return df.reset_index(drop=True)
+
+
+def build_sleep(sleep_df: pd.DataFrame) -> pd.DataFrame:
+    """Build the ``garmin_sleep`` frame (durations → seconds; ``end`` renamed)."""
+    df = sleep_df.copy()
+    df["day"] = _to_datetime(df.get("day")).dt.normalize()
+    df["sleep_start"] = _to_datetime(df.get("start"))
+    df["sleep_end"] = _to_datetime(df.get("end"))
+
+    df["total_sleep_s"] = df.get("total_sleep").map(_duration_to_seconds)
+    df["deep_sleep_s"] = df.get("deep_sleep").map(_duration_to_seconds)
+    df["light_sleep_s"] = df.get("light_sleep").map(_duration_to_seconds)
+    df["rem_sleep_s"] = df.get("rem_sleep").map(_duration_to_seconds)
+    df["awake_s"] = df.get("awake").map(_duration_to_seconds)
+
+    for col in SLEEP_COLUMNS:
+        if col not in df.columns:
+            df[col] = None
+
+    df = df[SLEEP_COLUMNS].copy()
+    df = _cast_int_cols(df, _SLEEP_INT_COLS)
+    for col in ("avg_spo2", "avg_rr", "avg_stress"):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    df["qualifier"] = df["qualifier"].astype(object).where(df["qualifier"].notna(), None)
+    # Drop GarminDB placeholder rows that carry no usable sleep information.
+    # GarminDB seeds empty rows (total_sleep = 0, null timestamps) for days with
+    # no recorded sleep, so a row counts only when it has real sleep duration or a
+    # sleep start timestamp.
+    has_duration = pd.to_numeric(df["total_sleep_s"], errors="coerce").fillna(0) > 0
+    has_start = df["sleep_start"].notna()
+    df = df[has_duration | has_start]
+    return df.reset_index(drop=True)
+
+
+# =============================================================================
+# Orchestration + preflight
+# =============================================================================
+
+def transform_all(config: dict) -> Dict[str, pd.DataFrame]:
+    """Read GarminDB SQLite DBs and return clean ``workouts``/``timeseries``/``sleep``.
+
+    Performs preflight validation: source DBs exist, required tables present,
+    no duplicate generated ``workoutId``, and ``(activity_id, record)`` is unique.
+    """
+    db_dir = Path(config["GARMIN_DB_DIR"])
+    activities_db = db_dir / ACTIVITIES_DB
+    garmin_db = db_dir / GARMIN_DB
+
+    if not activities_db.exists():
+        raise FileNotFoundError(f"GarminDB activities database not found: {activities_db}")
+    if not garmin_db.exists():
+        raise FileNotFoundError(f"GarminDB main database not found: {garmin_db}")
+
+    print(f"  Reading activities from {activities_db}")
+    activities_df = _read_activities(activities_db)
+    print(f"  Reading activity_records from {activities_db}")
+    records_df = _read_activity_records(activities_db)
+    print(f"  Reading sleep from {garmin_db}")
+    sleep_df = _read_sleep(garmin_db)
+
+    workouts = build_workout_metadata(activities_df, records_df)
+
+    # ── workoutId integrity ─────────────────────────────────────────────────
+    # A null workoutId means start_time was unparseable → no reliable linkage.
+    missing_ids = int(workouts["workoutId"].isna().sum())
+    if missing_ids:
+        raise ValueError(
+            f"{missing_ids} activities have an unparseable start_time → null workoutId."
+        )
+    # workoutId is used as a join key downstream, so it must stay unique. Rather
+    # than fail the whole batch on a rare same-second collision, disambiguate the
+    # later activities with a numeric suffix (activity_id remains the durable PK).
+    workouts = _disambiguate_workout_ids(workouts)
+
+    workout_id_map = dict(zip(workouts["activity_id"], workouts["workoutId"]))
+    timeseries = build_timeseries(records_df, workout_id_map)
+    sleep = build_sleep(sleep_df)
+
+    if timeseries.duplicated(subset=["activity_id", "record"]).any():
+        raise ValueError("Duplicate (activity_id, record) rows found in activity_records.")
+
+    gps_count = int((workouts["gps_source"] != "none").sum())
+    print(
+        f"  Transformed: {len(workouts)} workouts ({gps_count} with GPS), "
+        f"{len(timeseries)} records, {len(sleep)} sleep nights"
+    )
+
+    return {"workouts": workouts, "timeseries": timeseries, "sleep": sleep}
+
+
+def _disambiguate_workout_ids(workouts: pd.DataFrame) -> pd.DataFrame:
+    """Ensure ``workoutId`` is unique by suffixing same-second collisions.
+
+    The first activity keeps the bare ``DD-MM-YYYY_HHMMSS`` id; subsequent
+    activities sharing it (ordered by ``start_time``, ``activity_id``) get
+    ``-2``, ``-3``, … so downstream joins on ``workoutId`` stay correct.
+    """
+    if not workouts["workoutId"].duplicated().any():
+        return workouts
+
+    df = workouts.sort_values(["workoutId", "start_time", "activity_id"]).copy()
+    counts: Dict[str, int] = {}
+    new_ids = []
+    collisions = set()
+    for wid in df["workoutId"]:
+        n = counts.get(wid, 0) + 1
+        counts[wid] = n
+        if n == 1:
+            new_ids.append(wid)
+        else:
+            collisions.add(wid)
+            new_ids.append(f"{wid}-{n}")
+    df["workoutId"] = new_ids
+    print(
+        f"  ⚠️  Disambiguated {len(collisions)} same-second workoutId collision(s) "
+        f"with numeric suffixes: {sorted(collisions)}"
+    )
+    return df.reset_index(drop=True)
+
+
+__all__ = [
+    "transform_all",
+    "build_workout_metadata",
+    "build_timeseries",
+    "build_sleep",
+    "WORKOUT_COLUMNS",
+    "TIMESERIES_COLUMNS",
+    "SLEEP_COLUMNS",
+]

--- a/jobs/import-garmin/main.py
+++ b/jobs/import-garmin/main.py
@@ -1,0 +1,115 @@
+"""Garmin Import Job — entry point.
+
+Workflow:
+1. Load configuration (DATABASE_TYPE switch, paths, toggles).
+2. (Optional) Download phase — refresh GarminDB SQLite via the GarminDB CLI
+   (only when GARMIN_DOWNLOAD=true; best-effort, falls back to existing DBs).
+3. Transform — read GarminDB SQLite into clean DataFrames (workout metadata with
+   workoutId + first GPS, per-second timeseries, daily sleep).
+4. Load — upsert into DuckDB or PostgreSQL based on DATABASE_TYPE.
+5. Print a summary.
+
+Configuration is loaded from environment variables (via a .env file).
+"""
+import sys
+from pathlib import Path
+
+# Make the job directory importable so `garmin_etl` resolves regardless of cwd.
+job_dir = Path(__file__).resolve().parent
+sys.path.insert(0, str(job_dir))
+
+from garmin_etl.config import load_garmin_configuration
+from garmin_etl import transform as transform_layer
+
+
+def main() -> None:
+    print("=" * 80)
+    print("GARMIN IMPORT JOB — Heart Rate (workouts) + Sleep")
+    print("=" * 80)
+    print()
+
+    # ── Step 1: Configuration ───────────────────────────────────────────────
+    print("Step 1: Loading configuration...")
+    try:
+        config = load_garmin_configuration()
+    except (ValueError, FileNotFoundError) as exc:
+        print(f"❌ ERROR: Configuration failed: {exc}")
+        sys.exit(1)
+    print()
+
+    db_type = config["DATABASE_TYPE"]
+    if db_type == "postgres":
+        from garmin_etl.storage import postgres as storage
+    else:
+        from garmin_etl.storage import duckdb as storage
+
+    # ── Step 2: Optional download ───────────────────────────────────────────
+    if config["GARMIN_DOWNLOAD"]:
+        print("Step 2: Downloading latest data from Garmin (GarminDB CLI)...")
+        print("-" * 60)
+        download_required = config.get("GARMIN_DOWNLOAD_REQUIRED", True)
+        try:
+            from garmin_etl import download as download_layer
+
+            ok = download_layer.run_download(config)
+            if not ok:
+                if download_required:
+                    print(
+                        "❌ ERROR: Download phase failed and GARMIN_DOWNLOAD_REQUIRED is "
+                        "true. Aborting so stale data is not mistaken for a fresh import."
+                    )
+                    sys.exit(1)
+                print("⚠️  Download phase failed; continuing with existing SQLite DBs.")
+        except (FileNotFoundError, RuntimeError) as exc:
+            print(f"❌ ERROR: {exc}")
+            sys.exit(1)
+        except Exception as exc:  # noqa: BLE001 - best-effort phase
+            if download_required:
+                print(f"❌ ERROR: Download phase error: {exc}")
+                sys.exit(1)
+            print(f"⚠️  Download phase error: {exc}")
+            print("   Continuing with existing SQLite DBs.")
+        print()
+    else:
+        print("Step 2: Download phase disabled (transform-only). Skipping.")
+        print()
+
+    # ── Step 3: Transform ───────────────────────────────────────────────────
+    print("Step 3: Transforming GarminDB SQLite data...")
+    print("-" * 60)
+    try:
+        frames = transform_layer.transform_all(config)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"❌ ERROR: Transform failed: {exc}")
+        sys.exit(1)
+    workouts_df = frames["workouts"]
+    timeseries_df = frames["timeseries"]
+    sleep_df = frames["sleep"]
+    print()
+
+    # ── Step 4: Load ────────────────────────────────────────────────────────
+    print(f"Step 4: Loading into {db_type.upper()}...")
+    print("-" * 60)
+    try:
+        workout_counts = storage.import_workouts(workouts_df, timeseries_df, config)
+        sleep_counts = storage.import_sleep(sleep_df, config)
+    except Exception as exc:  # noqa: BLE001
+        print(f"❌ ERROR: Database load failed: {exc}")
+        sys.exit(1)
+    print()
+
+    # ── Done ────────────────────────────────────────────────────────────────
+    print("=" * 80)
+    print("✅ GARMIN IMPORT JOB COMPLETE")
+    print("=" * 80)
+    print(f"  - Database type:        {db_type.upper()}")
+    print(f"  - Workouts imported:    {len(workouts_df)} (table total {workout_counts['workouts']})")
+    print(f"  - Timeseries rows:      {len(timeseries_df)} (table total {workout_counts['timeseries']})")
+    print(f"  - Sleep nights:         {len(sleep_df)} (table total {sleep_counts['sleep']})")
+    if db_type == "duckdb":
+        print(f"  - DuckDB file:          {config['GARMIN_DUCKDB_PATH']}")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/jobs/import-garmin/notebooks/query_garmin_duckdb.md
+++ b/jobs/import-garmin/notebooks/query_garmin_duckdb.md
@@ -1,0 +1,156 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.6
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Query Garmin DuckDB tables
+
+Explore the Garmin data imported by the `import-garmin` job:
+
+- `garmin_workout_metadata` — one row per workout (`workoutId`, GPS, HR summary)
+- `garmin_timeseries` — per-second heart rate + GPS track
+- `garmin_sleep` — daily sleep summary
+
+> This notebook is excluded from the Docker image. Open it as a notebook via the
+> Jupytext extension, or run the cells in any environment with `duckdb` + `pandas`.
+
+```{code-cell} ipython3
+import os
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+
+pd.set_option("display.max_columns", None)
+
+# Resolve the Garmin DuckDB file. Defaults to the job's local_data mount; this
+# notebook lives in jobs/import-garmin/notebooks/, so we search upward from the
+# working directory for `local_data/garmin.duckdb` to stay robust to where the
+# notebook is launched from.
+def _resolve_duckdb_path() -> Path:
+    env_path = os.getenv("GARMIN_DUCKDB_PATH")
+    if env_path:
+        p = Path(env_path)
+        return p if p.is_absolute() else (Path.cwd() / p)
+    for base in [Path.cwd(), *Path.cwd().parents]:
+        candidate = base / "local_data" / "garmin.duckdb"
+        if candidate.exists():
+            return candidate
+        # Also handle running from inside the job dir's parent levels.
+        candidate = base / "jobs" / "import-garmin" / "local_data" / "garmin.duckdb"
+        if candidate.exists():
+            return candidate
+    return Path.cwd() / "local_data" / "garmin.duckdb"
+
+
+GARMIN_DUCKDB_PATH = _resolve_duckdb_path()
+
+print(f"DuckDB: {GARMIN_DUCKDB_PATH}  (exists={GARMIN_DUCKDB_PATH.exists()})")
+con = duckdb.connect(str(GARMIN_DUCKDB_PATH), read_only=True)
+```
+
+## Table overview
+
+```{code-cell} ipython3
+con.execute(
+    """
+    SELECT 'garmin_workout_metadata' AS table_name, COUNT(*) AS rows FROM garmin_workout_metadata
+    UNION ALL SELECT 'garmin_timeseries', COUNT(*) FROM garmin_timeseries
+    UNION ALL SELECT 'garmin_sleep', COUNT(*) FROM garmin_sleep
+    """
+).fetchdf()
+```
+
+## Recent workouts (with workoutId + GPS)
+
+```{code-cell} ipython3
+con.execute(
+    """
+    SELECT workoutId, activity_id, sport, start_time, stop_time,
+           ROUND(distance, 1) AS distance_m, calories, avg_hr, max_hr,
+           gps_lat, gps_long, gps_source
+    FROM garmin_workout_metadata
+    ORDER BY start_time DESC
+    LIMIT 15
+    """
+).fetchdf()
+```
+
+## GPS coverage of workouts
+
+```{code-cell} ipython3
+con.execute(
+    """
+    SELECT gps_source, COUNT(*) AS workouts
+    FROM garmin_workout_metadata
+    GROUP BY gps_source
+    ORDER BY workouts DESC
+    """
+).fetchdf()
+```
+
+## Heart-rate timeseries for the most recent workout
+
+```{code-cell} ipython3
+latest_workout = con.execute(
+    "SELECT workoutId FROM garmin_workout_metadata ORDER BY start_time DESC LIMIT 1"
+).fetchone()[0]
+print(f"workoutId: {latest_workout}")
+
+con.execute(
+    """
+    SELECT record, timestamp, hr, position_lat, position_long, speed
+    FROM garmin_timeseries
+    WHERE workoutId = ?
+    ORDER BY record
+    LIMIT 20
+    """,
+    [latest_workout],
+).fetchdf()
+```
+
+## HR summary per workout (computed from timeseries)
+
+```{code-cell} ipython3
+con.execute(
+    """
+    SELECT m.workoutId, m.sport, m.start_time,
+           COUNT(t.hr) AS hr_samples,
+           MIN(t.hr) AS min_hr, AVG(t.hr)::INT AS mean_hr, MAX(t.hr) AS max_hr
+    FROM garmin_workout_metadata m
+    JOIN garmin_timeseries t USING (workoutId)
+    GROUP BY m.workoutId, m.sport, m.start_time
+    ORDER BY m.start_time DESC
+    LIMIT 15
+    """
+).fetchdf()
+```
+
+## Sleep trend
+
+```{code-cell} ipython3
+con.execute(
+    """
+    SELECT day,
+           ROUND(total_sleep_s / 3600.0, 2) AS total_sleep_h,
+           ROUND(deep_sleep_s / 3600.0, 2)  AS deep_sleep_h,
+           ROUND(rem_sleep_s / 3600.0, 2)   AS rem_sleep_h,
+           score, qualifier
+    FROM garmin_sleep
+    ORDER BY day DESC
+    LIMIT 21
+    """
+).fetchdf()
+```
+
+```{code-cell} ipython3
+con.close()
+```

--- a/jobs/import-garmin/pyproject.toml
+++ b/jobs/import-garmin/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "garmin-import-job"
+version = "0.1.0"
+description = "Import Garmin heart-rate (workouts) and sleep data into DuckDB or PostgreSQL"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "pandas>=2.0.0",
+    "numpy>=1.24.0",
+    "duckdb>=0.9.0",
+    "psycopg[binary]>=3.0.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.optional-dependencies]
+# Only needed when GARMIN_DOWNLOAD=true (the optional live download phase).
+# Pinned to 3.7.0 to match the garth-based single-file `garth_session` token
+# format already in use (3.8.0 switched to a different token-store mechanism).
+download = [
+    "garmindb==3.7.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["garmin_etl"]
+
+[tool.uv]

--- a/jobs/import-garmin/scripts/renew_garmin_token.py
+++ b/jobs/import-garmin/scripts/renew_garmin_token.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Renew the Garmin (garth) session token used by the import-garmin download phase.
+
+Garmin authentication is an OAuth SSO flow (login widget -> optional MFA ->
+OAuth1 token -> OAuth2 exchange) that the ``garth`` library implements; it cannot
+be done in pure shell. This script logs in interactively and writes a fresh token
+in the single-file ``garth_session`` format expected by the pinned
+``garmindb==3.7.0``.
+
+It is normally invoked by ``scripts/renew_garmin_token.sh`` (which ensures
+``garth`` is installed), but can also be run directly:
+
+    python scripts/renew_garmin_token.py
+    GARMIN_EMAIL=you@example.com python scripts/renew_garmin_token.py
+    python scripts/renew_garmin_token.py --token-file /path/to/garth_session
+
+This file is host-only and excluded from the Docker image (see .dockerignore).
+"""
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Renew the Garmin garth session token.")
+    parser.add_argument(
+        "--token-file",
+        default=os.environ.get("GARMIN_TOKEN_FILE", os.path.expanduser("~/.GarminDb/garth_session")),
+        help="Where to write the token (default: ~/.GarminDb/garth_session).",
+    )
+    parser.add_argument(
+        "--domain",
+        default=os.environ.get("GARMIN_DOMAIN", "garmin.com"),
+        help="Garmin domain (default: garmin.com; use garmin.cn for China).",
+    )
+    parser.add_argument(
+        "--email",
+        default=os.environ.get("GARMIN_EMAIL"),
+        help="Garmin account email (otherwise prompted).",
+    )
+    args = parser.parse_args()
+
+    try:
+        import garth
+    except ImportError:
+        print(
+            "ERROR: the 'garth' package is not installed.\n"
+            "Install it with: pip install 'garmindb==3.7.0'  (or run scripts/renew_garmin_token.sh).",
+            file=sys.stderr,
+        )
+        return 1
+
+    token_file = os.path.expanduser(args.token_file)
+    email = args.email or input("Garmin email: ").strip()
+    password = getpass.getpass("Garmin password: ")
+
+    print(f"Renewing Garmin token -> {token_file}")
+    print(f"Domain: {args.domain}\n")
+
+    client = garth.Client()
+    client.configure(domain=args.domain)
+
+    # Prompts for an MFA one-time code on stdin if 2FA is enabled on the account.
+    try:
+        client.login(email, password)
+    except Exception as exc:  # noqa: BLE001 - surface a friendly message
+        message = str(exc)
+        if "401" in message or "Unauthorized" in message:
+            print(
+                "\n\u274c Login failed: Garmin rejected the credentials (401 Unauthorized).\n"
+                "   Double-check your email/password (and MFA code if prompted) and try again.",
+                file=sys.stderr,
+            )
+        else:
+            print(f"\n\u274c Login failed: {exc}", file=sys.stderr)
+        return 1
+
+    os.makedirs(os.path.dirname(token_file), exist_ok=True)
+    with open(token_file, "w", encoding="utf-8") as handle:
+        handle.write(client.dumps())
+
+    print(f"\n\u2705 Fresh token saved to {token_file}")
+    try:
+        print(f"   Logged in as: {client.profile.get('displayName', '?')}")
+    except Exception:  # noqa: BLE001 - profile is best-effort
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/jobs/import-garmin/scripts/renew_garmin_token.sh
+++ b/jobs/import-garmin/scripts/renew_garmin_token.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Renew the Garmin (garth) session token used by the import-garmin download phase.
+#
+# This is a thin, pure-shell wrapper: it makes sure the `garth` dependency is
+# available and then runs `renew_garmin_token.py`, which performs the actual
+# Garmin login. The login itself (OAuth SSO + MFA + token minting) requires the
+# `garth` Python library and cannot be done in pure shell.
+#
+# It logs in interactively (prompts for email, password, and an MFA code if your
+# account has 2FA) and writes a fresh token in the single-file `garth_session`
+# format this job's pinned `garmindb==3.7.0` expects.
+#
+# Usage (from the job directory jobs/import-garmin):
+#   ./scripts/renew_garmin_token.sh                                  # writes ~/.GarminDb/garth_session
+#   GARMIN_TOKEN_FILE=/path/to/garth_session ./scripts/renew_garmin_token.sh
+#   GARMIN_EMAIL=you@example.com ./scripts/renew_garmin_token.sh     # skip the email prompt
+#   GARMIN_DOMAIN=garmin.cn ./scripts/renew_garmin_token.sh          # China region
+#
+# After it prints "Fresh token saved", re-run the job:
+#   docker compose up --build --abort-on-container-exit
+#
+# This file is excluded from the Docker image (see .dockerignore).
+
+set -euo pipefail
+
+# This script lives in jobs/import-garmin/scripts/. The uv project (pyproject.toml)
+# is in the parent job directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JOB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Pick a runner for renew_garmin_token.py: prefer the job's uv project (it has
+# garth via the 'download' extra), otherwise fall back to a plain `python3`.
+if command -v uv >/dev/null 2>&1; then
+    echo "Ensuring download dependencies (garth) are installed via uv..."
+    uv sync --project "$JOB_DIR" --extra download >/dev/null
+    exec uv run --project "$JOB_DIR" python "$SCRIPT_DIR/renew_garmin_token.py" "$@"
+elif command -v python3 >/dev/null 2>&1; then
+    exec python3 "$SCRIPT_DIR/renew_garmin_token.py" "$@"
+else
+    echo "ERROR: neither 'uv' nor 'python3' found on PATH." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a new containerized import job at **`jobs/import-garmin/`** that imports **Garmin per-workout heart rate** (with `workoutId` + GPS) and **sleep** data into **DuckDB** or **PostgreSQL**, selectable via `DATABASE_TYPE` — mirroring the existing Polar job at `jobs/import/`.

Data originates from the [GarminDB](https://github.com/tcgoetz/GarminDB) SQLite databases. By default the job transforms already-downloaded SQLite data; optionally it can download fresh data from Garmin Connect first.

## What gets imported

| Table | Source | Description |
|-------|--------|-------------|
| `garmin_workout_metadata` | `activities` | One row per workout. PK `activity_id`; carries `workoutId` (`DD-MM-YYYY_HHMMSS`) and `gps_lat`/`gps_long`/`gps_source` (first valid GPS fix). |
| `garmin_timeseries` | `activity_records` | Per-second `hr`, `position_lat/long`, `speed`, `distance`, … linked by `activity_id` + `workoutId`. |
| `garmin_sleep` | `sleep` | Daily sleep summary; durations as integer seconds; reserved `end` → `sleep_end`. |

## Key design

- **Two data layers** (`garmin_etl/storage/{duckdb,postgres}.py`) with explicit DDL and **idempotent delete-by-id upserts**; chosen at runtime by `DATABASE_TYPE` (`.env` switch).
- **`workoutId`** built as `DD-MM-YYYY_HHMMSS` from activity start time (Polar convention) and linked as a key via the metadata table; `activity_id` is the durable PK; same-second collisions are auto-disambiguated.
- **First GPS coordinate** per workout stored in the metadata (first valid fix, fallback to activity start; `gps_source` records origin).
- **Optional live download** (`GARMIN_DOWNLOAD=true`) runs the GarminDB CLI via a `garth` session token. Pinned to `garmindb==3.7.0` (single-file token format). Includes a **preflight token-expiry check** and **CLI failure-marker detection** so an auth failure never silently imports stale data; `GARMIN_DOWNLOAD_REQUIRED` aborts on a failed required download. Empty GarminDB placeholder sleep rows are filtered out.
- Data stored under **`local_data/`** (mounted, gitignored).

## Layout

- `main.py` — orchestrator (optional download → transform → load → summary)
- `garmin_etl/` — `config.py`, `transform.py`, `download.py`, `storage/{duckdb,postgres}.py`
- `notebooks/query_garmin_duckdb.md` — DuckDB query notebook (**excluded from the Docker image**)
- `scripts/renew_garmin_token.{sh,py}` — host-only garth token renewal (**excluded from the Docker image**)

## Verification (in Docker, both backends)

- **Transform-only:** 193 workouts / 80,295 timeseries rows / 135 sleep nights; idempotent; PostgreSQL parity verified.
- **Live download:** 293 workouts (289 with GPS) / 112,983 rows / 205 sleep nights, fresh through the current date; container exits 0; all integrity checks pass (unique/valid `workoutId`, 0 null/orphan timeseries links, only genuine sleep nights).

Full details and evidence in `docs/reports/2026-06-08_garmin_import_job.md` and `docs/reports/2026-06-08_garmin_import_download_run.md`.

## How to run

```bash
cd jobs/import-garmin
cp .env.example .env
# transform-only (default): seed local_data/garmin_sqlite/DBs with GarminDB SQLite, then:
docker compose up --build
# live download: set GARMIN_DOWNLOAD=true, then renew the token + run:
./scripts/renew_garmin_token.sh
docker compose up --build
```

## Notes

- No secrets or data are committed (`.env`, `local_data/`, tokens are gitignored).
- The live download requires an interactive Garmin login + MFA to mint the garth token (host-only).