### PR TITLE
chore(docker): bump import job base image to python:3.14-slim

### DIFF
--- a/jobs/import-garmin/Dockerfile
+++ b/jobs/import-garmin/Dockerfile
@@ -3,7 +3,7 @@
 # The optional live-download phase (GARMIN_DOWNLOAD=true) additionally needs the
 # 'download' extra (garmindb); enable it by switching the uv sync line below.
 
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 # Install uv (fast Python package manager).
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/jobs/import/Dockerfile
+++ b/jobs/import/Dockerfile
@@ -2,7 +2,7 @@
 # Downloads TCX from Polar API, converts to CSV, uploads to Azure,
 # imports into database (DuckDB or PostgreSQL), and cleans up.
 
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 # Install system dependencies, Azure CLI, and uv
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary
Replaces the `python:3.11-slim` base image (reported to carry **3 critical vulnerabilities**) with the latest stable **`python:3.14-slim`** (Python 3.14.5) in both import-job Dockerfiles.

| File | Change |
|------|--------|
| `jobs/import/Dockerfile` (Polar import job) | `FROM python:3.11-slim` → `FROM python:3.14-slim` |
| `jobs/import-garmin/Dockerfile` (Garmin import job) | `FROM python:3.11-slim` → `FROM python:3.14-slim` |

Only the `FROM` line changed in each file — no dependency or code changes were required. `garmindb==3.7.0` (Garmin download extra) installs cleanly on Python 3.14.

## Verification (local Docker, both exit 0)
- **Polar** — ran in local DuckDB mode (Azure disabled): built on CPython 3.14.5, imported 25 exercises, `✅ POLAR IMPORT JOB COMPLETE`, exit 0.
- **Garmin** — ran transform-only (offline): built on CPython 3.14.5, imported 293 workouts / 112983 timeseries rows / 205 sleep nights, `✅ GARMIN IMPORT JOB COMPLETE`, exit 0.

Both images build with no extra fixes and the jobs run to completion.

🤖 Generated with Copilot CLI