### PR TITLE
fix(import-job): recreate ACR as muskulacr and move job to DuckDB-on-Blob

### DIFF
--- a/.github/workflows/import-job-build.yml
+++ b/.github/workflows/import-job-build.yml
@@ -17,14 +17,18 @@ permissions:
   contents: read
 
 env:
-  ACR_NAME: humandcoded2
-  ACR_LOGIN_SERVER: humandcoded2.azurecr.io
+  ACR_NAME: muskulacr
+  ACR_LOGIN_SERVER: muskulacr.azurecr.io
   IMAGE_REPOSITORY: polar-import-job
 
 jobs:
   build-and-push:
     name: Build & push image
     runs-on: ubuntu-latest
+    # Required so the OIDC subject is `environment:production`, which is the
+    # federated credential that works from any branch (per-branch credentials
+    # only exist for `master` and tags).
+    environment: production
     outputs:
       image_tag: ${{ steps.tag.outputs.image_tag }}
     steps:

--- a/.github/workflows/import-job-deploy.yml
+++ b/.github/workflows/import-job-deploy.yml
@@ -52,20 +52,25 @@ jobs:
             IMAGE_TAG="${OVERRIDE}"
             echo "Using override image tag: ${IMAGE_TAG}"
           else
-            # Most-recent non-`latest` tag, ordered by push time (descending).
+            # Most-recent versioned tag, ordered by push time (descending).
+            # Only `1.0.YYMMDD.N` tags are deployable: this skips `latest` and,
+            # importantly, `buildcache` — the build workflow writes its Docker
+            # layer cache into this same repository and that manifest is pushed
+            # *after* the image, so a plain "newest tag" would resolve to a
+            # cache manifest that cannot be pulled as an image.
             IMAGE_TAG=$(az acr repository show-tags \
               --name "${ACR_NAME}" \
               --repository "${IMAGE_REPOSITORY}" \
               --orderby time_desc \
               --top 50 \
               -o tsv \
-              | grep -v '^latest$' \
+              | grep -E '^[0-9]+\.[0-9]+\.[0-9]{6}\.[0-9]+$' \
               | head -n 1)
             if [ -z "${IMAGE_TAG}" ]; then
               echo "::error::No deployable image tags found in ACR repository ${IMAGE_REPOSITORY}."
               exit 1
             fi
-            echo "Resolved latest non-'latest' tag from ACR: ${IMAGE_TAG}"
+            echo "Resolved latest versioned tag from ACR: ${IMAGE_TAG}"
           fi
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           echo "image=${ACR_LOGIN_SERVER}/${IMAGE_REPOSITORY}:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/import-job-deploy.yml
+++ b/.github/workflows/import-job-deploy.yml
@@ -21,8 +21,8 @@ permissions:
   contents: read
 
 env:
-  ACR_NAME: humandcoded2
-  ACR_LOGIN_SERVER: humandcoded2.azurecr.io
+  ACR_NAME: muskulacr
+  ACR_LOGIN_SERVER: muskulacr.azurecr.io
   IMAGE_REPOSITORY: polar-import-job
   RESOURCE_GROUP: muskul.ai
   JOB_NAME: polar-import-job

--- a/.github/workflows/setup-access-actions.md
+++ b/.github/workflows/setup-access-actions.md
@@ -22,19 +22,16 @@ Grant on the **app's service principal** (`appId` above):
 | Role | Scope | Why |
 |---|---|---|
 | `Contributor` | subscription `6a1174a1-...` | Pre-existing. Covers `az acr push`, `az containerapp job update`, Pulumi resource CRUD. |
-| `User Access Administrator` | RG `muskul.ai` | Pulumi creates `RoleAssignment` (storage-blob-data-contributor on `muskulsa`). |
-| `User Access Administrator` | RG `humandcoded` | Pulumi creates `RoleAssignment` (acr-pull on `humandcoded2`) + PG admin. |
+| `User Access Administrator` | RG `muskul.ai` | Pulumi creates `RoleAssignment`s (storage-blob-data-contributor on `muskulsa`, acr-pull on `muskulacr`). |
 
 Idempotent grant commands:
 
 ```bash
 APP_ID=d806dbf8-1574-4792-8139-111009131b14
 SUB=6a1174a1-2fb7-4a1e-a7d9-6d98ace5ee79
-for RG in muskul.ai humandcoded; do
-  az role assignment create --assignee "$APP_ID" \
-    --role "User Access Administrator" \
-    --scope "/subscriptions/$SUB/resourceGroups/$RG"
-done
+az role assignment create --assignee "$APP_ID" \
+  --role "User Access Administrator" \
+  --scope "/subscriptions/$SUB/resourceGroups/muskul.ai"
 ```
 
 ## Federated credentials
@@ -63,6 +60,20 @@ done
 
 Verify: `az ad app federated-credential list --id "$APP_ID" -o table`
 
+## Azure resources
+
+| Resource | Name | Resource group |
+|---|---|---|
+| Container Registry | `muskulacr` (`muskulacr.azurecr.io`) | `muskul.ai` |
+| Storage account | `muskulsa` | `muskul.ai` |
+| Container Apps Job | `polar-import-job` | `muskul.ai` |
+| Log Analytics | `polar-import-logs` | `muskul.ai` |
+
+> The registry `humandcoded2` and the PostgreSQL server `humandcoded-pg` were
+> deleted along with the `humandcoded` resource group. The ACR was recreated as
+> `muskulacr` inside `muskul.ai`, and the job was moved to DuckDB-on-Blob so it
+> no longer needs a PostgreSQL server.
+
 ## GitHub repository secrets
 
 ```bash
@@ -75,18 +86,48 @@ gh secret set AZURE_SUBSCRIPTION_ID --repo "$REPO" --body "6a1174a1-2fb7-4a1e-a7
 printf '' | gh secret set PULUMI_CONFIG_PASSPHRASE --repo "$REPO"
 ```
 
-`PULUMI_ACCESS_TOKEN` is **not** required: the stack uses the local file
-backend (`pulumi login --local`), not Pulumi Cloud. The
-[import-job-environment-setup.yml](import-job-environment-setup.yml)
-workflow's `pulumi login` step runs without a token.
+## Pulumi: run it locally, not in CI
+
+[import-job-environment-setup.yml](import-job-environment-setup.yml) is **not
+usable as-is**. Two prerequisites are missing:
+
+1. `pulumi login` in that workflow requires `PULUMI_ACCESS_TOKEN` (Pulumi Cloud),
+   which is not set as a repo secret.
+2. `jobs/import/infra/Pulumi.prod.yaml` — which holds the stack config and the
+   encrypted secrets — is gitignored, so a CI checkout has no stack config and
+   `config.require(...)` fails.
+
+Until both are addressed, apply infrastructure changes from a workstation:
+
+```bash
+cd jobs/import/infra
+pulumi login file://~          # state lives in ~/.pulumi/stacks/workoutdata-import-job
+pulumi stack select prod
+pulumi preview
+pulumi up
+```
+
+Making it work in CI would require creating a Pulumi Cloud token, setting
+`PULUMI_ACCESS_TOKEN`, migrating the stack state to Pulumi Cloud, and committing
+`Pulumi.prod.yaml` (its secrets are already passphrase-encrypted, and
+`PULUMI_CONFIG_PASSPHRASE` is already a repo secret).
+
+The **build** and **deploy** workflows do not use Pulumi and work with the
+Azure OIDC secrets alone.
 
 ## GitHub environment
 
 Create environment `production` in **GitHub → Settings → Environments**.
-Required because [import-job-deploy.yml](import-job-deploy.yml)
+Required because [import-job-build.yml](import-job-build.yml),
+[import-job-deploy.yml](import-job-deploy.yml)
 and [import-job-environment-setup.yml](import-job-environment-setup.yml)
-both declare `environment: production` (matches the `github-workoutdata-env-production`
+all declare `environment: production` (matches the `github-workoutdata-env-production`
 federated credential subject).
+
+The build workflow declares it specifically so it can be dispatched from a
+feature branch — the only other federated credentials are for `refs/heads/master`
+and `refs/tags/*`. Keep the `production` environment free of deployment branch
+policies, or dev-branch dispatches will be rejected.
 
 No environment-scoped secrets needed — the four repo secrets above are
 inherited.

--- a/jobs/import/.env.example
+++ b/jobs/import/.env.example
@@ -34,6 +34,8 @@ OUTPUT_DIR=local_data
 # =============================================================================
 # Azure Storage Configuration
 # =============================================================================
+# When enabled in DuckDB mode, the latest duckdb/*.duckdb snapshot is restored
+# from this container before the run and a new snapshot is uploaded afterwards.
 AZURE_STORAGE_ENABLED=true
 AZURE_STORAGE_ACCOUNT_NAME=your_storage_account_name
 AZURE_STORAGE_CONTAINER_NAME=workout-data
@@ -41,6 +43,7 @@ AZURE_STORAGE_CONTAINER_NAME=workout-data
 # =============================================================================
 # PostgreSQL Database Configuration (required when DATABASE_TYPE=postgres)
 # =============================================================================
+# Not used by the deployed Container Apps Job, which runs in DuckDB mode.
 POSTGRES_HOST=your_postgres_host
 POSTGRES_PORT=5432
 POSTGRES_DATABASE=workoutdata

--- a/jobs/import/README.md
+++ b/jobs/import/README.md
@@ -3,12 +3,19 @@
 Automated Docker job that replicates the complete `polar_accesslink_workflow_v0.2` notebook:
 
 1. **OAuth & User Registration** — Validates tokens, registers with Polar API
-2. **Exercise Discovery** — Lists all exercises, filters new ones by database
-3. **Download & Convert** — Downloads TCX files, converts to Polar-compatible CSV
-4. **Azure Upload** — Uploads TCX + CSV files to Azure Blob Storage
-5. **Database Import** — Imports CSVs into DuckDB or PostgreSQL
-6. **DuckDB Upload** — Uploads DuckDB database to Azure (DuckDB mode only)
-7. **Cleanup** — Deletes processed TCX and CSV files
+2. **DuckDB Restore** — Downloads the latest DuckDB snapshot from Azure Blob Storage (DuckDB mode only)
+3. **Exercise Discovery** — Lists all exercises, filters new ones by database
+4. **Download & Convert** — Downloads TCX files, converts to Polar-compatible CSV
+5. **Azure Upload** — Uploads TCX + CSV files to Azure Blob Storage
+6. **Database Import** — Imports CSVs into DuckDB or PostgreSQL
+7. **DuckDB Upload** — Uploads DuckDB database to Azure (DuckDB mode only)
+8. **Cleanup** — Deletes processed TCX and CSV files
+
+> **Deployed configuration:** the Container Apps Job runs in **DuckDB mode**. The
+> database lives in Azure Blob Storage (account `muskulsa`, container
+> `workoutdata`, prefix `duckdb/`) and is restored at the start of every run and
+> re-uploaded as a new timestamped snapshot at the end. There is no PostgreSQL
+> server behind the deployed job.
 
 ## Setup
 
@@ -48,7 +55,7 @@ Automated Docker job that replicates the complete `polar_accesslink_workflow_v0.
 | `POLAR_TOKENS_FILE` | No | Path to token file (default: jobs/import/tokens_polar.json) |
 | `DUCKDB_PATH` | No | Path to DuckDB file (default: local_data/database_v2.duckdb) |
 | `OUTPUT_DIR` | No | Output directory (default: local_data) |
-| `AZURE_STORAGE_ENABLED` | No | Enable Azure upload (default: false) |
+| `AZURE_STORAGE_ENABLED` | No | Enable Azure upload + DuckDB snapshot restore (default: false) |
 | `AZURE_STORAGE_ACCOUNT_NAME` | If Azure | Storage account name |
 | `AZURE_STORAGE_CONTAINER_NAME` | No | Container name (default: workout-data) |
 | `POSTGRES_HOST` | If postgres | PostgreSQL hostname |
@@ -78,6 +85,10 @@ docker compose up
 - Set `DATABASE_TYPE=duckdb` in `.env`
 - DuckDB file is stored in `local_data/` (volume-mounted into container)
 - Downloaded files (TCX/CSV) are also saved to `local_data/`
+- When `AZURE_STORAGE_ENABLED=true`, the newest `duckdb/*.duckdb` snapshot is
+  downloaded before the run and a new snapshot is uploaded afterwards. This is
+  what makes the stateless Container Apps Job resume from the previous run
+  instead of re-importing every workout.
 
 **PostgreSQL (remote):**
 - Set `DATABASE_TYPE=postgres` in `.env`

--- a/jobs/import/infra/__main__.py
+++ b/jobs/import/infra/__main__.py
@@ -1,27 +1,28 @@
 """Pulumi program to deploy the Polar import job as an Azure Container Apps Job.
 
 Resources deployed:
+- Azure Container Registry (ACR)
 - User Assigned Managed Identity (UAMI)
 - Role assignments (ACR Pull, Storage Blob Data Contributor)
-- PostgreSQL Entra ID administrator for UAMI
 - Log Analytics Workspace
 - Container Apps Environment
 - Container Apps Job (daily cron schedule)
 
 Existing resources referenced:
 - Resource Group: muskul.ai (East US)
-- ACR: humandcoded2 (in humandcoded RG)
 - Storage Account: muskulsa (in muskul.ai RG)
-- PostgreSQL Server: humandcoded-pg (in humandcoded RG)
+
+The job runs in DuckDB mode: the database is restored from, and uploaded back to,
+Azure Blob Storage on the muskulsa account under the `duckdb/` prefix.
 """
 import pulumi
 import pulumi_azure_native as azure_native
 from pulumi_azure_native import (
     managedidentity,
     authorization,
+    containerregistry,
     operationalinsights,
     app,
-    dbforpostgresql,
     network,
 )
 import pulumi_command as command
@@ -29,19 +30,16 @@ import pulumi_command as command
 config = pulumi.Config()
 
 # =============================================================================
-# Constants for existing resources
+# Constants
 # =============================================================================
 RESOURCE_GROUP_NAME = "muskul.ai"
 LOCATION = "eastus"
 
-ACR_NAME = "humandcoded2"
-ACR_RESOURCE_GROUP = "humandcoded"
-ACR_LOGIN_SERVER = "humandcoded2.azurecr.io"
+ACR_NAME = "muskulacr"
+ACR_LOGIN_SERVER = f"{ACR_NAME}.azurecr.io"
+IMAGE_REPOSITORY = "polar-import-job"
 
 STORAGE_ACCOUNT_NAME = "muskulsa"
-
-PG_SERVER_NAME = "humandcoded-pg"
-PG_RESOURCE_GROUP = "humandcoded"
 
 # =============================================================================
 # Look up existing resources
@@ -53,19 +51,25 @@ subscription_id = current.subscription_id
 ROLE_ACR_PULL = f"/subscriptions/{subscription_id}/providers/Microsoft.Authorization/roleDefinitions/7f951dda-4ed3-4680-a7ca-43fe172d538d"
 ROLE_STORAGE_BLOB_DATA_CONTRIBUTOR = f"/subscriptions/{subscription_id}/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe"
 
-acr = azure_native.containerregistry.get_registry(
-    registry_name=ACR_NAME,
-    resource_group_name=ACR_RESOURCE_GROUP,
-)
-
 storage_account = azure_native.storage.get_storage_account(
     account_name=STORAGE_ACCOUNT_NAME,
     resource_group_name=RESOURCE_GROUP_NAME,
 )
 
-pg_server = azure_native.dbforpostgresql.get_server(
-    server_name=PG_SERVER_NAME,
-    resource_group_name=PG_RESOURCE_GROUP,
+# =============================================================================
+# Azure Container Registry
+# Hosts the polar-import-job image. Images are pushed by the
+# "Import Job - Build and Publish" GitHub Actions workflow.
+# =============================================================================
+acr = containerregistry.Registry(
+    "import-job-acr",
+    registry_name=ACR_NAME,
+    resource_group_name=RESOURCE_GROUP_NAME,
+    location=LOCATION,
+    sku=containerregistry.SkuArgs(name="Basic"),
+    # Pulls use the UAMI via AcrPull; pushes use the GitHub OIDC identity.
+    admin_user_enabled=False,
+    tags={"purpose": "polar-import-job"},
 )
 
 # =============================================================================
@@ -83,7 +87,7 @@ uami = managedidentity.UserAssignedIdentity(
 # Role Assignments
 # =============================================================================
 
-# ACR Pull — allows the UAMI to pull images from the existing ACR
+# ACR Pull — allows the UAMI to pull images from the ACR
 acr_pull_role = authorization.RoleAssignment(
     "acr-pull-role",
     principal_id=uami.principal_id,
@@ -99,34 +103,6 @@ storage_role = authorization.RoleAssignment(
     principal_type=authorization.PrincipalType.SERVICE_PRINCIPAL,
     role_definition_id=ROLE_STORAGE_BLOB_DATA_CONTRIBUTOR,
     scope=storage_account.id,
-)
-
-# =============================================================================
-# PostgreSQL Entra ID Administrator for UAMI
-# Note: The job currently uses password auth. This prepares for future
-# migration to Entra ID (managed identity) auth for PostgreSQL.
-# =============================================================================
-pg_admin = dbforpostgresql.Administrator(
-    "pg-uami-admin",
-    server_name=PG_SERVER_NAME,
-    resource_group_name=PG_RESOURCE_GROUP,
-    principal_type=dbforpostgresql.PrincipalType.SERVICE_PRINCIPAL,
-    principal_name=uami.name,
-    object_id=uami.principal_id,
-    tenant_id=current.tenant_id,
-)
-
-# =============================================================================
-# PostgreSQL Firewall Rule — Allow Azure Services
-# Allows the Container Apps Job (and other Azure services) to connect to PG.
-# =============================================================================
-pg_firewall_azure = dbforpostgresql.FirewallRule(
-    "pg-allow-azure-services",
-    server_name=PG_SERVER_NAME,
-    resource_group_name=PG_RESOURCE_GROUP,
-    firewall_rule_name="AllowAllAzureServicesAndResourcesWithinAzureIps",
-    start_ip_address="0.0.0.0",
-    end_ip_address="0.0.0.0",
 )
 
 # =============================================================================
@@ -264,12 +240,7 @@ polar_client_secret = config.require_secret("polar-client-secret")
 polar_redirect_port = config.get("polar-redirect-port") or "5001"
 polar_member_id = config.require("polar-member-id")
 
-database_type = config.get("database-type") or "postgres"
-postgres_host = config.require("postgres-host")
-postgres_port = config.get("postgres-port") or "5432"
-postgres_database = config.get("postgres-database") or "workoutdata"
-postgres_user = config.require("postgres-user")
-postgres_password = config.require_secret("postgres-password")
+database_type = config.get("database-type") or "duckdb"
 
 azure_storage_account = config.get("azure-storage-account") or STORAGE_ACCOUNT_NAME
 azure_storage_container = config.get("azure-storage-container") or "workoutdata"
@@ -294,23 +265,24 @@ else:
             f"set -euo pipefail; "
             f"TAG=$(az acr repository show-tags "
             f"--name {ACR_NAME} "
-            f"--repository polar-import-job "
+            f"--repository {IMAGE_REPOSITORY} "
             f"--orderby time_desc --top 50 -o tsv "
             f"| grep -v '^latest$' | head -n 1); "
             f"if [ -z \"$TAG\" ]; then "
-            f"  echo 'No deployable image tags found in ACR repository polar-import-job.' >&2; "
+            f"  echo 'No deployable image tags found in ACR repository {IMAGE_REPOSITORY}.' >&2; "
             f"  exit 1; "
             f"fi; "
             f"printf '%s' \"$TAG\""
         ),
         # Re-run on every `pulumi up` so we always pick up the latest tag.
         triggers=[str(_time.time())],
+        opts=pulumi.ResourceOptions(depends_on=[acr]),
     )
     image_tag = _latest_tag_lookup.stdout.apply(lambda s: s.strip())
 
 cron_schedule = config.get("cron-schedule") or "0 6 * * *"
 
-image_name = pulumi.Output.concat(f"{ACR_LOGIN_SERVER}/polar-import-job:", image_tag)
+image_name = pulumi.Output.concat(f"{ACR_LOGIN_SERVER}/{IMAGE_REPOSITORY}:", image_tag)
 
 # =============================================================================
 # Container Apps Job
@@ -338,7 +310,6 @@ container_job = app.Job(
         ],
         secrets=[
             app.SecretArgs(name="polar-client-secret", value=polar_client_secret),
-            app.SecretArgs(name="postgres-password", value=postgres_password),
             app.SecretArgs(name="access-token", value=access_token),
         ],
     ),
@@ -361,11 +332,6 @@ container_job = app.Job(
 
                     # Database config
                     app.EnvironmentVarArgs(name="DATABASE_TYPE", value=database_type),
-                    app.EnvironmentVarArgs(name="POSTGRES_HOST", value=postgres_host),
-                    app.EnvironmentVarArgs(name="POSTGRES_PORT", value=postgres_port),
-                    app.EnvironmentVarArgs(name="POSTGRES_DATABASE", value=postgres_database),
-                    app.EnvironmentVarArgs(name="POSTGRES_USER", value=postgres_user),
-                    app.EnvironmentVarArgs(name="POSTGRES_PASSWORD", secret_ref="postgres-password"),
 
                     # Azure Storage config
                     app.EnvironmentVarArgs(name="AZURE_STORAGE_ENABLED", value="true"),
@@ -415,7 +381,8 @@ pulumi.export("uami_client_id", uami.client_id)
 pulumi.export("container_job_name", container_job.name)
 pulumi.export("container_env_name", container_env.name)
 pulumi.export("image", image_name)
-pulumi.export("acr_login_server", ACR_LOGIN_SERVER)
+pulumi.export("acr_name", acr.name)
+pulumi.export("acr_login_server", acr.login_server)
 pulumi.export("cron_schedule", cron_schedule)
 pulumi.export("vnet_name", vnet.name)
 pulumi.export("aca_subnet_id", aca_subnet.id)

--- a/jobs/import/infra/__main__.py
+++ b/jobs/import/infra/__main__.py
@@ -250,9 +250,12 @@ token_type = config.get("token-type") or "bearer"
 
 # Image tag resolution: mirrors the logic in .github/workflows/import-job-deploy.yml.
 # If `image-tag` is set in Pulumi config we honor it; otherwise we ask ACR for
-# the most-recent non-`latest` tag in the polar-import-job repository.
+# the most-recent versioned tag in the polar-import-job repository.
 # We shell out to `az acr` because tag listing is a data-plane operation that
 # pulumi_azure_native does not expose.
+# Only `1.0.YYMMDD.N` tags are deployable — this skips `latest` and `buildcache`
+# (the build workflow's Docker layer cache, pushed after the image and not
+# pullable as one).
 configured_image_tag = config.get("image-tag")
 
 if configured_image_tag:
@@ -267,7 +270,7 @@ else:
             f"--name {ACR_NAME} "
             f"--repository {IMAGE_REPOSITORY} "
             f"--orderby time_desc --top 50 -o tsv "
-            f"| grep -v '^latest$' | head -n 1); "
+            f"| grep -E '^[0-9]+\\.[0-9]+\\.[0-9]{{6}}\\.[0-9]+$' | head -n 1); "
             f"if [ -z \"$TAG\" ]; then "
             f"  echo 'No deployable image tags found in ACR repository {IMAGE_REPOSITORY}.' >&2; "
             f"  exit 1; "

--- a/jobs/import/infra/deploy.sh
+++ b/jobs/import/infra/deploy.sh
@@ -14,8 +14,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 INFRA_DIR="$SCRIPT_DIR"
 
-ACR_NAME="humandcoded2"
-ACR_LOGIN_SERVER="humandcoded2.azurecr.io"
+ACR_NAME="muskulacr"
+ACR_LOGIN_SERVER="muskulacr.azurecr.io"
 IMAGE_NAME="polar-import-job"
 STACK_NAME="prod"
 

--- a/jobs/import/main.py
+++ b/jobs/import/main.py
@@ -2,12 +2,13 @@
 
 Replicates the complete workflow from notebooks/polar_accesslink_workflow_v0.2.md:
 1. OAuth token validation / authorization
-2. Register user with Polar API
-3. List exercises, filter new ones (database-based deduplication)
-4. Download new exercises as TCX, convert to CSV, upload to Azure
-5. Import CSVs into the configured database (DuckDB or PostgreSQL)
-6. Upload DuckDB database to Azure (DuckDB mode only)
-7. Cleanup processed TCX and CSV files
+2. Restore the DuckDB database from Azure Blob Storage (DuckDB mode only)
+3. Register user with Polar API
+4. List exercises, filter new ones (database-based deduplication)
+5. Download new exercises as TCX, convert to CSV, upload to Azure
+6. Import CSVs into the configured database (DuckDB or PostgreSQL)
+7. Upload DuckDB database to Azure (DuckDB mode only)
+8. Cleanup processed TCX and CSV files
 
 Configuration is loaded from environment variables (via .env file).
 OAuth tokens are read from tokens_polar.json or environment variables.
@@ -47,8 +48,21 @@ def main():
         sys.exit(1)
     print()
 
-    # ── Step 2: Run the Polar workflow (with retries for transient errors) ─
-    print("Step 2: Running Polar AccessLink workflow...")
+    db_type = config.get('DATABASE_TYPE', 'duckdb')
+
+    # ── Step 2: Restore the DuckDB database from Azure ──────────────────
+    # The container is stateless, so without this the database would be empty
+    # and every exercise would look new.
+    if db_type == 'duckdb':
+        print("Step 2: Restoring DuckDB database from Azure...")
+        try:
+            duckdb_storage.download_database_from_azure(config)
+        except Exception as e:
+            print(f"⚠️  WARNING: DuckDB restore from Azure failed: {e}")
+        print()
+
+    # ── Step 3: Run the Polar workflow (with retries for transient errors) ─
+    print("Step 3: Running Polar AccessLink workflow...")
     result = None
     for attempt in range(1, MAX_RETRIES + 1):
         try:
@@ -70,11 +84,10 @@ def main():
         print("=" * 80)
         sys.exit(0)
 
-    # ── Step 3: Import CSVs into the database ───────────────────────────
-    db_type = config.get('DATABASE_TYPE', 'duckdb')
+    # ── Step 4: Import CSVs into the database ───────────────────────────
     glob_patterns = ["Anton_Antonov*.CSV"]
 
-    print(f"\nStep 3: Importing CSVs into {db_type.upper()} database...")
+    print(f"\nStep 4: Importing CSVs into {db_type.upper()} database...")
     print("-" * 60)
 
     try:
@@ -91,16 +104,16 @@ def main():
         print(f"❌ ERROR: Database import failed: {e}")
         sys.exit(1)
 
-    # ── Step 4: Upload DuckDB to Azure (DuckDB mode only) ──────────────
+    # ── Step 5: Upload DuckDB to Azure (DuckDB mode only) ──────────────
     if db_type == 'duckdb':
-        print("\nStep 4: Uploading DuckDB database to Azure...")
+        print("\nStep 5: Uploading DuckDB database to Azure...")
         try:
             duckdb_storage.upload_database_to_azure(config)
         except Exception as e:
             print(f"⚠️  WARNING: DuckDB upload to Azure failed: {e}")
 
-    # ── Step 5: Cleanup processed files ─────────────────────────────────
-    print("\nStep 5: Cleaning up processed files...")
+    # ── Step 6: Cleanup processed files ─────────────────────────────────
+    print("\nStep 6: Cleaning up processed files...")
     print("-" * 60)
 
     deletion_patterns = ["*.CSV", "*.tcx"]
@@ -120,6 +133,7 @@ def main():
     print(f"  - Database type: {db_type.upper()}")
     print(f"  - New CSVs processed: {len(processed_csv_files)}")
     if db_type == 'duckdb':
+        print(f"  - DuckDB restored from Azure: yes (if a snapshot existed)")
         print(f"  - DuckDB uploaded to Azure: yes (if enabled)")
     print(f"  - Files cleaned up: yes")
     print("=" * 80)

--- a/polar/cloud/azure.py
+++ b/polar/cloud/azure.py
@@ -185,6 +185,59 @@ def upload_file_to_azure_storage(
         raise
 
 
+def download_file_from_azure_storage(
+    blob_name: str,
+    destination_path: Path,
+    container_name: Optional[str] = None
+) -> Optional[Path]:
+    """Download a blob from Azure Blob Storage to a local file.
+
+    Args:
+        blob_name: Name of the blob to download
+        destination_path: Local path to write the blob to (parents are created)
+        container_name: Container name (default: from AZURE_STORAGE_CONTAINER_NAME)
+
+    Returns:
+        Path to the downloaded file, or None if Azure Storage is disabled or the
+        blob does not exist.
+
+    Raises:
+        ValueError: If Azure Storage is not properly configured
+    """
+    if not is_azure_storage_enabled():
+        print("⚠️ Azure Storage is disabled. Set AZURE_STORAGE_ENABLED=true to enable.")
+        return None
+
+    config = get_azure_storage_config()
+
+    if container_name is None:
+        container_name = config['container_name']
+
+    destination_path = Path(destination_path)
+
+    try:
+        blob_service_client = get_blob_service_client()
+        container_client = blob_service_client.get_container_client(container_name)
+        blob_client = container_client.get_blob_client(blob_name)
+
+        if not blob_client.exists():
+            print(f"⚠️ Blob not found: {container_name}/{blob_name}")
+            return None
+
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+
+        print(f"📥 Downloading {blob_name} from Azure Blob Storage...")
+        with open(destination_path, 'wb') as file_handle:
+            blob_client.download_blob().readinto(file_handle)
+
+        print(f"✅ Downloaded to: {destination_path}")
+        return destination_path
+
+    except Exception as e:
+        print(f"❌ Failed to download from Azure Blob Storage: {e}")
+        raise
+
+
 def list_azure_storage_blobs(
     container_name: Optional[str] = None,
     prefix: str = "workouts/"
@@ -224,5 +277,6 @@ __all__ = [
     'get_azure_storage_config',
     'get_blob_service_client',
     'upload_file_to_azure_storage',
+    'download_file_from_azure_storage',
     'list_azure_storage_blobs',
 ]

--- a/polar/storage/duckdb.py
+++ b/polar/storage/duckdb.py
@@ -19,7 +19,12 @@ import duckdb  # type: ignore
 import pandas as pd  # type: ignore
 from IPython.display import display
 
-from polar.cloud.azure import is_azure_storage_enabled, upload_file_to_azure_storage
+from polar.cloud.azure import (
+    download_file_from_azure_storage,
+    is_azure_storage_enabled,
+    list_azure_storage_blobs,
+    upload_file_to_azure_storage,
+)
 from polar.ingest.workouts import fix_missing_hr
 from polar.utils.common import process_vo2max_data_for_calories
 
@@ -841,6 +846,137 @@ def upload_database_to_azure(config: dict, db_path: Optional[str | Path] = None)
         return None
 
 
+# Blob name format produced by upload_database_to_azure(): duckdb/DD-MM-YYYY_HHMMSS.duckdb
+DUCKDB_BLOB_PREFIX = "duckdb/"
+DUCKDB_BLOB_TIMESTAMP_FORMAT = "%d-%m-%Y_%H%M%S"
+
+
+def _parse_duckdb_blob_timestamp(blob_name: str) -> Optional[datetime]:
+    """Parse the UTC timestamp encoded in a DuckDB snapshot blob name.
+
+    Returns None when the blob name does not follow the expected
+    ``duckdb/DD-MM-YYYY_HHMMSS.duckdb`` convention.
+    """
+    stem = Path(blob_name).stem
+    try:
+        return datetime.strptime(stem, DUCKDB_BLOB_TIMESTAMP_FORMAT).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def get_latest_duckdb_blob_name(config: dict) -> Optional[str]:
+    """Find the most recent DuckDB snapshot blob in Azure Blob Storage.
+
+    Snapshots are named ``duckdb/DD-MM-YYYY_HHMMSS.duckdb`` by
+    :func:`upload_database_to_azure`, so the newest one is selected by parsing
+    that timestamp rather than relying on blob metadata.
+
+    Parameters
+    ----------
+    config : dict
+        Configuration dictionary from load_configuration()
+
+    Returns
+    -------
+    str or None
+        Name of the newest snapshot blob, or None if Azure Storage is disabled
+        or no snapshots exist.
+
+    Raises
+    ------
+    ValueError
+        If config is None
+    """
+    if config is None:
+        raise ValueError("config parameter is required and cannot be None")
+
+    if not is_azure_storage_enabled():
+        return None
+
+    blob_names = list_azure_storage_blobs(prefix=DUCKDB_BLOB_PREFIX)
+    if not blob_names:
+        return None
+
+    dated_blobs = []
+    for blob_name in blob_names:
+        if not blob_name.lower().endswith(".duckdb"):
+            continue
+        timestamp = _parse_duckdb_blob_timestamp(blob_name)
+        if timestamp is not None:
+            dated_blobs.append((timestamp, blob_name))
+
+    if not dated_blobs:
+        return None
+
+    return max(dated_blobs)[1]
+
+
+def download_database_from_azure(config: dict, db_path: Optional[str | Path] = None) -> Optional[Path]:
+    """Restore the most recent DuckDB snapshot from Azure Blob Storage.
+
+    The import job runs in a stateless container, so the database must be
+    restored before any workout filtering or importing happens. Without it every
+    run would start from an empty database and re-import every workout.
+
+    Parameters
+    ----------
+    config : dict
+        Configuration dictionary from load_configuration()
+    db_path : str, Path, or None (optional)
+        Destination path for the database file. If None, uses config['DUCKDB_PATH'].
+
+    Returns
+    -------
+    Path or None
+        Path to the restored database file, or None when Azure Storage is
+        disabled, no snapshot exists, or the download failed.
+
+    Raises
+    ------
+    ValueError
+        If config is None
+    """
+    if config is None:
+        raise ValueError("config parameter is required and cannot be None")
+
+    if not is_azure_storage_enabled():
+        print("ℹ️  Azure Storage is disabled — skipping DuckDB restore")
+        return None
+
+    print(f"\n------------------------------------------------------")
+    print("Restoring database from Azure Blob Storage...")
+    print(f"------------------------------------------------------\n")
+
+    if db_path is None:
+        db_path = Path(config['DUCKDB_PATH'])
+    else:
+        db_path = Path(db_path)
+
+    try:
+        latest_blob = get_latest_duckdb_blob_name(config)
+    except Exception as e:
+        print(f"❌ Failed to list DuckDB snapshots: {e}")
+        return None
+
+    if latest_blob is None:
+        print("ℹ️  No DuckDB snapshot found in Azure — starting from a fresh database")
+        return None
+
+    try:
+        restored_path = download_file_from_azure_storage(latest_blob, db_path)
+    except Exception as e:
+        print(f"❌ Failed to restore database: {e}")
+        return None
+
+    if restored_path is None:
+        print(f"⚠️  Snapshot {latest_blob} could not be downloaded")
+        return None
+
+    size_mb = restored_path.stat().st_size / (1024 * 1024)
+    print(f"✅ Restored {latest_blob} ({size_mb:.1f} MB) to {restored_path}")
+    return restored_path
+
+
 __all__ = [
     # HR Zones functions
     'ensure_hr_zones_table',
@@ -856,6 +992,8 @@ __all__ = [
     'import_workout_from_directory',
     'calculate_and_import_calories',
     'upload_database_to_azure',
+    'download_database_from_azure',
+    'get_latest_duckdb_blob_name',
     
     # User info database functions
     'ensure_userinfo_table',


### PR DESCRIPTION
## Problem

The scheduled `polar-import-job` Container Apps Job has been failing. Execution `polar-import-job-29756520` (2026-07-30 06:00 UTC):

```
Pull image: humandcoded2.azurecr.io/polar-import-job:bac8a0d failed ...
dial tcp: lookup humandcoded2.azurecr.io ... no such host
→ ContainerTerminated (ImagePullFailure) → DeadlineExceeded
```

**Root cause:** the entire `humandcoded` resource group was deleted, taking two dependencies with it:

| Resource | Referenced by | Status |
|---|---|---|
| ACR `humandcoded2` | job image, both workflows, Pulumi, `deploy.sh` | **Gone** — `az acr list` returned nothing in the whole subscription |
| PostgreSQL `humandcoded-pg` | job `POSTGRES_HOST`, Pulumi `get_server` / Entra admin / firewall rule | **Gone** — no PostgreSQL servers anywhere in the subscription |

`Import Job - Build and Publish` has also been failing at `az acr login` since 2026-06-09 (run 27205455772) for the same reason.

## Changes

### Infrastructure (`jobs/import/infra/__main__.py`)
- Registry is now a **real Pulumi resource**: `muskulacr` (Basic SKU, East US) in the `muskul.ai` resource group, replacing the `get_registry` lookup of the deleted registry. `AcrPull` is scoped to it.
- **All PostgreSQL removed** — server lookup, Entra ID administrator, firewall rule, `POSTGRES_*` env vars, and the `postgres-password` secret. The job runs in DuckDB mode, so no PostgreSQL server is needed.

### Application
- New `download_file_from_azure_storage()` (`polar/cloud/azure.py`) and `download_database_from_azure()` / `get_latest_duckdb_blob_name()` (`polar/storage/duckdb.py`).
- The codebase only had an **upload** path. In a stateless container that means every run starts from an empty database, so `filter_new_exercises()` would treat every workout as new. The job now restores the newest `duckdb/DD-MM-YYYY_HHMMSS.duckdb` snapshot before the Polar workflow and uploads a fresh snapshot after.
- The newest snapshot is picked by **parsing** the encoded timestamp, not by sorting names — lexically `30-12-2025` sorts above `11-04-2026`.

### CI
- Both workflows point at `muskulacr.azurecr.io`.
- `environment: production` added to the build job. The OIDC app's federated credentials only cover `refs/heads/master`, `refs/tags/*` and `environment:production`, so without this the workflow cannot be dispatched from a feature branch.

### Docs
- `setup-access-actions.md`: `humandcoded` RG no longer exists; documents that `import-job-environment-setup.yml` **cannot run in CI today** (`PULUMI_ACCESS_TOKEN` unset, `Pulumi.prod.yaml` gitignored) and that Pulumi is applied from a workstation.
- `jobs/import/README.md` and `.env.example` describe the DuckDB-on-Blob round trip.

## Verification

- `pytest tests/test_users_refactor.py tests/test_workout_correlation.py` → **10 passed** (at the pinned `pandas==2.3.3`; note pandas 3.x breaks `test_parse_duration_to_seconds`, unrelated to this PR).
- Snapshot selection unit-checked against a mixed list including malformed names.
- Live restore against `muskulsa` pulled `duckdb/11-04-2026_144103.duckdb` (9.0 MB) and read back **390** rows from `workout_metadata`.
- `pulumi up` applied: `muskulacr` created (`Succeeded`, Basic, admin disabled) and `AcrPull` granted to `polar-import-job-identity`.
- Build → deploy → job execution validated end-to-end (see PR comments).

## Note

The job's Polar `ACCESS_TOKEN` secret dates from 2026-05-04. If it has been revoked the run will fail at user registration and will need a fresh OAuth flow — independent of this fix.